### PR TITLE
chore(cicd): Configure Dependabot for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps): update github-actions"


### PR DESCRIPTION
Add GitHub Actions to Dependabot configuration.

#### Related

<!-- Issue #, Vulnerability, References if available:* -->

#### Changes

<!-- Description of changes:* -->
Added the `.github/dependabot.yml` for the "github-actions" package ecosystem.

#### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agent-plugins/blob/main/LICENSE).
