### PR TITLE
fix(tools): fix cross-ref validator path handling and add to CI

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -49,3 +49,6 @@ jobs:
 
       - name: Validate JSON manifests
         run: mise run lint:manifests
+
+      - name: Validate cross-references
+        run: mise run lint:cross-refs

--- a/tools/validate-cross-refs.cjs
+++ b/tools/validate-cross-refs.cjs
@@ -76,9 +76,14 @@ function validatePlugin(plugin) {
   info(`Validating plugin: ${pluginName}`);
 
   // Determine plugin directory path
+  // Source can be relative to repo root (./plugins/foo) or to plugins dir (./foo)
   const source = plugin.source || `./${pluginName}`;
   const normalizedSource = source.replace(/^\.\//, "").replace(/\/$/, "");
-  const pluginDir = path.join(PLUGINS_ROOT, normalizedSource);
+
+  // If source already includes plugins/ prefix, use as-is; otherwise prepend PLUGINS_ROOT
+  const pluginDir = normalizedSource.startsWith(`${PLUGINS_ROOT}/`)
+    ? normalizedSource
+    : path.join(PLUGINS_ROOT, normalizedSource);
 
   // Check 1: Plugin directory exists
   if (!fs.existsSync(pluginDir)) {


### PR DESCRIPTION
## Summary

Fix cross-ref validator path bug and add missing CI step for parity between local and GitHub CI.

## Changes

- **Fix doubled path bug**: The validator was unconditionally prepending `plugins/` to the source path, causing `plugins/plugins/deploy-on-aws` when marketplace.json uses repo-root-relative paths (`./plugins/foo`)
- **Add CI parity**: Add `lint:cross-refs` step to GitHub workflow (was missing, causing local `mise run ci` to differ from remote CI)

## Test Plan

- [x] Verified fix with temp plugin structures:
  - Repo-root-relative path (`./plugins/foo`) - resolves correctly
  - Plugins-dir-relative path (`./foo`) - resolves correctly  
  - Missing plugin directory - error logged
  - Name mismatch - error logged
  - No skills directory - warning logged
- [x] `mise run ci` passes locally