### PR TITLE
feat: update CODEOWNERS for deploy-on-aws team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,6 +28,10 @@ README.md                 @awslabs/agent-plugins-admins
 schemas/                  @awslabs/agent-plugins-admins
 tools/                    @awslabs/agent-plugins-admins
 
+## Plugins (alphabetically listed)
+
+plugins/deploy-on-aws     @awslabs/agent-plugins-admins @awslabs/agent-plugins-maintainers  @awslabs/agent-plugins-deploy-on-aws
+
 ## File must end with CODEOWNERS file
 
 .github/CODEOWNERS         @awslabs/agent-plugins-admins


### PR DESCRIPTION
Added CODEOWNERS entry for deploy-on-aws plugin.

<!-- Summarize the pull request -->

#### Related

<!-- Issue #, Vulnerability, References if available:* -->

#### Changes

<!-- Description of changes:* -->
Using the `.github/CODEOWNERS` file for code ownership to teams.

#### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agent-plugins/blob/main/LICENSE).
