### PR TITLE
feat: add PR attribution and document Claude Code setup

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,9 @@
   "permissions": {
     "allow": []
   },
+  "attribution": {
+    "pr": "🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---\n\nBy submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agent-plugins/blob/main/LICENSE)."
+  },
   "enabledPlugins": {
     "code-review@claude-plugins-official": true,
     "pr-review-toolkit@claude-plugins-official": true,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,8 @@ Depending on your role, please review the appropriate guide for repository-speci
 - [Development Guide](./docs/DEVELOPMENT_GUIDE.md) - For contributors and developers
 - [Maintainers Guide](./docs/MAINTAINERS_GUIDE.md) - For reviewers, maintainers, and admins
 
+**Using Claude Code?** See the [Claude Code Setup](./docs/DEVELOPMENT_GUIDE.md#claude-code-setup) section in the Development Guide for project-specific configuration.
+
 ## Reporting Bugs/Feature Requests
 
 We welcome you to use the GitHub issue tracker to report bugs or suggest features.

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -31,6 +31,10 @@ Run this once inside a Claude Code session:
 
 After adding the marketplace, the plugins listed in `.claude/settings.json` will activate automatically for this project.
 
+### PR contributor statement
+
+The project-level `attribution.pr` setting automatically appends the required contributor statement to pull request descriptions created by Claude Code, so the `contributorStatement` CI check passes without manual copy-paste.
+
 ## Working on Your Contribution
 
 | Action                                            | Explanation                                                                                                                                                                                                                                                                                     |


### PR DESCRIPTION
## Summary
- Adds `attribution.pr` to `.claude/settings.json` so Claude Code automatically appends the required contributor statement to PR descriptions, preventing CI failures from the `contributorStatement` check
- Adds a note in `CONTRIBUTING.md` pointing Claude Code users to the Development Guide
- Documents the `attribution.pr` setting in the [Claude Code Setup](./docs/DEVELOPMENT_GUIDE.md#claude-code-setup) section of the Development Guide

## Test plan
- [x] Create a PR using Claude Code and verify the description includes both the Claude Code attribution and the contributor statement
- [x] Verify the `contributorStatement` CI check passes on this PR

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agent-plugins/blob/main/LICENSE).