### PR TITLE
feat(github): detect mutations in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,8 @@ jobs:
       actions: read
       contents: read
     runs-on: ubuntu-latest
+    outputs:
+      self_mutation_happened: ${{ steps.self_mutation.outputs.self_mutation_happened }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -38,3 +40,26 @@ jobs:
 
       - name: Build
         run: mise run build
+
+      - name: Find mutations
+        id: self_mutation
+        run: |-
+          git add .
+          git diff --staged --patch --exit-code > repo.patch || echo "self_mutation_happened=true" >> $GITHUB_OUTPUT
+        shell: bash
+        working-directory: ./
+
+      - name: Upload patch
+        if: steps.self_mutation.outputs.self_mutation_happened
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.4.0
+        with:
+          name: repo.patch
+          path: repo.patch
+          overwrite: true
+
+      - name: Fail build on mutation
+        if: steps.self_mutation.outputs.self_mutation_happened
+        run: |-
+          echo "::error::Files were changed during build (see build log). Please run the build locally and commit the changes."
+          cat repo.patch
+          exit 1


### PR DESCRIPTION
<!-- Summarize the pull request -->

Example of run here: https://github.com/krokoko/agent-plugins/actions/runs/22108130741/job/63896638469

Add mutation detection to the Build workflow so CI fails when the build produces uncommitted changes (e.g. generated or reformatted files). The workflow records the diff as an artifact and fails the job with a clear error so contributors fix and commit the changes.

<!-- Issue #, Vulnerability, References if available:* -->

Build job
- Output: self_mutation_happened set when the build changes any tracked files.
- Find mutations: After mise run build, run git add . and git diff --staged --patch --exit-code > repo.patch; if there are changes, set self_mutation_happened=true in GITHUB_OUTPUT.
- Upload patch: When a mutation is detected, upload repo.patch as a workflow artifact so reviewers can see the diff.
- Fail build on mutation: When a mutation is detected, log an error, print the patch, and exit 1 so the build fails.
- Permissions: Unchanged (top-level all none; build job actions: read, contents: read).

Use case example
- A PR adds a new script that the linter/formatter or another build step modifies (e.g. dprint or markdownlint --fix would change files).
- The author forgets to run mise run build (or mise run fmt / mise run lint:md:fix) locally and commit the result.
- On push, the Build workflow runs: build succeeds, then “Find mutations” sees uncommitted changes.
- The workflow uploads repo.patch and the “Fail build on mutation” step runs: the job fails with a message like “Files were changed during build (see build log). Please run the build locally and commit the changes.” and the patch is shown in the log.
- The author runs the build locally, commits the generated/formatted changes, and pushes again; the build then passes.

#### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agent-plugins/blob/main/LICENSE).
