### PR TITLE
fix: Apache 2.0 license and code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,36 +2,37 @@
 
 ## Default owners for everything in the repo
 
-*                         @awslabs/agent-plugins-admins @awslabs/agent-plugins-maintainers
+*                                   @awslabs/agent-plugins-admins @awslabs/agent-plugins-maintainers
 
 ## Adminstrators
 
-.bandit-baseline.json     @awslabs/agent-plugins-admins
-.claude-plugin/           @awslabs/agent-plugins-admins
-.github/                  @awslabs/agent-plugins-admins
-.gitignore                @awslabs/agent-plugins-admins
-.gitleaks-baseline.json   @awslabs/agent-plugins-admins
-.gitleaks.toml            @awslabs/agent-plugins-admins
-.gitleaksignore           @awslabs/agent-plugins-admins
-.markdownlint-cli2.yaml   @awslabs/agent-plugins-admins
-AGENTS.md                 @awslabs/agent-plugins-admins
-CLAUDE.md                 @awslabs/agent-plugins-admins
-CODE_OF_CONDUCT.md        @awslabs/agent-plugins-admins
-CONTRIBUTING.md           @awslabs/agent-plugins-admins
-docs/                     @awslabs/agent-plugins-admins
-dprint.json               @awslabs/agent-plugins-admins
-LICENSE                   @awslabs/agent-plugins-admins
-mise.toml                 @awslabs/agent-plugins-admins
-NOTICE                    @awslabs/agent-plugins-admins
-plugins/                  @awslabs/agent-plugins-admins
-README.md                 @awslabs/agent-plugins-admins
-schemas/                  @awslabs/agent-plugins-admins
-tools/                    @awslabs/agent-plugins-admins
+.bandit-baseline.json               @awslabs/agent-plugins-admins
+.claude-plugin/                     @awslabs/agent-plugins-admins
+.github/                            @awslabs/agent-plugins-admins
+.gitignore                          @awslabs/agent-plugins-admins
+.gitleaks-baseline.json             @awslabs/agent-plugins-admins
+.gitleaks.toml                      @awslabs/agent-plugins-admins
+.gitleaksignore                     @awslabs/agent-plugins-admins
+.markdownlint-cli2.yaml             @awslabs/agent-plugins-admins
+AGENTS.md                           @awslabs/agent-plugins-admins
+CLAUDE.md                           @awslabs/agent-plugins-admins
+CODE_OF_CONDUCT.md                  @awslabs/agent-plugins-admins
+CONTRIBUTING.md                     @awslabs/agent-plugins-admins
+docs/                               @awslabs/agent-plugins-admins
+dprint.json                         @awslabs/agent-plugins-admins
+LICENSE                             @awslabs/agent-plugins-admins
+mise.toml                           @awslabs/agent-plugins-admins
+NOTICE                              @awslabs/agent-plugins-admins
+plugins/                            @awslabs/agent-plugins-admins
+README.md                           @awslabs/agent-plugins-admins
+schemas/                            @awslabs/agent-plugins-admins
+tools/                              @awslabs/agent-plugins-admins
 
 ## Plugins (alphabetically listed)
 
-plugins/deploy-on-aws     @awslabs/agent-plugins-admins @awslabs/agent-plugins-maintainers  @awslabs/agent-plugins-deploy-on-aws
+plugins/amazon-location-service     @awslabs/agent-plugins-admins @awslabs/agent-plugins-maintainers  @awslabs/agent-plugins-agent-plugins-amazon-location-service
+plugins/deploy-on-aws               @awslabs/agent-plugins-admins @awslabs/agent-plugins-maintainers  @awslabs/agent-plugins-deploy-on-aws
 
 ## File must end with CODEOWNERS file
 
-.github/CODEOWNERS         @awslabs/agent-plugins-admins
+.github/CODEOWNERS                  @awslabs/agent-plugins-admins

--- a/plugins/amazon-location-service/.claude-plugin/plugin.json
+++ b/plugins/amazon-location-service/.claude-plugin/plugin.json
@@ -1,10 +1,8 @@
 {
-  "name": "amazon-location-service",
-  "description": "Guide developers through adding maps, places search, geocoding, routing, and other geospatial features with Amazon Location Service, including authentication setup, SDK integration, and best practices.",
-  "version": "1.0.0",
   "author": {
     "name": "Amazon Web Services"
   },
+  "description": "Guide developers through adding maps, places search, geocoding, routing, and other geospatial features with Amazon Location Service, including authentication setup, SDK integration, and best practices.",
   "keywords": [
     "location",
     "maps",
@@ -18,6 +16,8 @@
     "address",
     "coordinates"
   ],
+  "license": "Apache-2.0",
+  "name": "amazon-location-service",
   "repository": "https://github.com/awslabs/agent-plugins",
-  "license": "MIT-0"
+  "version": "1.0.0"
 }

--- a/plugins/amazon-location-service/.mcp.json
+++ b/plugins/amazon-location-service/.mcp.json
@@ -1,11 +1,11 @@
 {
   "mcpServers": {
     "aws-mcp": {
-      "command": "uvx",
       "args": [
         "mcp-proxy-for-aws@latest",
         "https://aws-mcp.us-east-1.api.aws/mcp"
-      ]
+      ],
+      "command": "uvx"
     }
   }
 }


### PR DESCRIPTION
Use `Apache 2.0` license.

#### Related

<!-- Issue #, Vulnerability, References if available:* -->

#### Changes

* Added CODEOWNER line
* Sorted JSON

<!-- Description of changes:* -->

#### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agent-plugins/blob/main/LICENSE).
