### PR TITLE
docs: remove dead references to .claude/docs/

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -19,7 +19,6 @@ globs:
 # Files to ignore
 ignores:
   - "**/node_modules/**"
-  - ".claude/docs/**"
 
 # Rule configuration
 config:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,15 +104,6 @@ agent-plugins/
 
 Default to **dev sizing** unless user says "production".
 
-## Reference Documentation
-
-See `.claude/docs/` for Claude Code plugin system reference:
-
-- `plugin_overview.md` - Creating plugins
-- `plugin_marketplace_distribution.md` - Marketplace distribution
-- `plugin_reference.md` - Complete technical reference
-- `skills_docs.md` - Skill authoring guide
-
 ## Development commands (mise)
 
 The project uses [mise](https://mise.jdx.dev) for tool versions and tasks. Ensure mise is installed, then from the repo root:

--- a/docs/DESIGN_GUIDELINES.md
+++ b/docs/DESIGN_GUIDELINES.md
@@ -571,7 +571,5 @@ Before submitting a plugin, verify:
 ## Additional Resources
 
 - [Agent Skills specification](https://agentskills.io/specification) - Official format for SKILL.md frontmatter and directory structure
-- `.claude/docs/skills_docs.md` - Skill authoring technical reference
-- `.claude/docs/plugin_reference.md` - Plugin manifest specification
 - `../schemas/` - JSON schemas for validation
 - `../CLAUDE.md` - Repository-specific instructions

--- a/dprint.json
+++ b/dprint.json
@@ -3,8 +3,7 @@
   "excludes": [
     "**/node_modules/**",
     "**/.git/**",
-    "**/dist/**",
-    "**/.claude/docs/**"
+    "**/dist/**"
   ],
   "indentWidth": 2,
   "json": {


### PR DESCRIPTION
## Summary

- Remove "Reference Documentation" section from `AGENTS.md` that referenced four non-existent files under `.claude/docs/`
- Remove two dead `.claude/docs/` links from `docs/DESIGN_GUIDELINES.md` "Additional Resources" section
- Remove stale `.claude/docs/**` ignore/exclude rules from `.markdownlint-cli2.yaml` and `dprint.json`

These files were temporary Claude docs created and removed within the initial PR (#1, commit message: "fix: removing temporary Claude docs") but the references to them were never cleaned up.

## Test plan

- [x] `mise run build` passes (lint, format check, security scanners all green)
- [x] No remaining references to `.claude/docs` in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agent-plugins/blob/main/LICENSE).