### PR TITLE
fix(tools): add actionable guidance when validate-urls is missing httpx

### DIFF
--- a/tools/validate-urls.py
+++ b/tools/validate-urls.py
@@ -233,6 +233,16 @@ async def main_async(strict: bool) -> int:
 
 
 def main() -> int:
+    try:
+        import httpx  # noqa: F401
+    except ModuleNotFoundError:
+        print(
+            f"{RED}Missing dependency: httpx.{RESET}\n"
+            "Run this script via `uv run tools/validate-urls.py` "
+            "or install httpx in your environment."
+        )
+        return 2
+
     strict = "--strict" in sys.argv
     return asyncio.run(main_async(strict))
 


### PR DESCRIPTION
## What changed
- Added a dependency guard in `tools/validate-urls.py` that catches `ModuleNotFoundError` for `httpx`.
- Replaced the raw traceback with an actionable message telling contributors to run the script with `uv run` (or install `httpx`).
- Returned exit code `2` for this missing-dependency case so CI/local tooling can detect setup issues clearly.

## Why
- Running `python3 tools/validate-urls.py` in an environment without `httpx` currently fails with a Python traceback.
- This small change improves contributor UX by surfacing a clear, direct remediation path instead of an internal stack trace.
- Behavior is unchanged when `httpx` is installed.

## Testing
- `scripts/clone_and_test.sh awslabs/agent-plugins`
  - Tests: not run (no tests found)
- `python3 tools/validate-urls.py`
  - Verified graceful missing-dependency message and exit code `2` when `httpx` is not installed.

#### Acknowledgment
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agent-plugins/blob/main/LICENSE).
