### PR TITLE
fix: correct nosemgrep rule IDs for sagemaker-ai and tools

### DIFF
--- a/plugins/sagemaker-ai/skills/dataset-evaluation/scripts/format_detector.py
+++ b/plugins/sagemaker-ai/skills/dataset-evaluation/scripts/format_detector.py
@@ -653,7 +653,7 @@ if __name__ == "__main__":
         if args.json:
             output = {
                 "format_type": result.format_type.value,
-                "is_valid": result.is_valid,  # nosemgrep: python.lang.maintainability.is-function-without-parentheses -- dataclass field, not a method
+                "is_valid": result.is_valid,  # nosemgrep: python.lang.maintainability.is-function-without-parentheses.is-function-without-parentheses -- dataclass field, not a method
                 "confidence": result.confidence.value,
                 "lines_sampled": result.lines_sampled,
                 "errors": [
@@ -664,7 +664,7 @@ if __name__ == "__main__":
             print(json.dumps(output, indent=2))
         else:
             print(f"Format: {result.format_type.value}")
-            print(f"Valid: {'✓' if result.is_valid else '✗'}")  # nosemgrep: python.lang.maintainability.is-function-without-parentheses -- dataclass field, not a method
+            print(f"Valid: {'✓' if result.is_valid else '✗'}")  # nosemgrep: python.lang.maintainability.is-function-without-parentheses.is-function-without-parentheses -- dataclass field, not a method
             print(f"Confidence: {result.confidence.name}")
             print(f"Lines sampled: {result.lines_sampled}")
             if result.errors:
@@ -672,7 +672,7 @@ if __name__ == "__main__":
                 for err in result.errors:
                     print(f"  Line {err.line_number}: {err.message}")
         
-        sys.exit(0 if result.is_valid else 1)  # nosemgrep: python.lang.maintainability.is-function-without-parentheses -- dataclass field, not a method
+        sys.exit(0 if result.is_valid else 1)  # nosemgrep: python.lang.maintainability.is-function-without-parentheses.is-function-without-parentheses -- dataclass field, not a method
     except (FileNotFoundError, IOError, ValueError) as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)

--- a/tools/validate-cross-refs.cjs
+++ b/tools/validate-cross-refs.cjs
@@ -51,6 +51,7 @@ function info(message) {
 
 function validateMarketplace(marketplacePath, manifestPathParts) {
   // Check marketplace.json exists
+  // nosemgrep: gitlab.eslint.detect-non-literal-fs-filename, javascript.lang.security.audit.detect-non-literal-fs-filename.detect-non-literal-fs-filename -- callers pass hardcoded constants, not user input
   if (!fs.existsSync(marketplacePath)) {
     error(`Marketplace file not found: ${marketplacePath}`);
     return;
@@ -58,6 +59,7 @@ function validateMarketplace(marketplacePath, manifestPathParts) {
 
   let marketplace;
   try {
+    // nosemgrep: gitlab.eslint.detect-non-literal-fs-filename, javascript.lang.security.audit.detect-non-literal-fs-filename.detect-non-literal-fs-filename -- callers pass hardcoded constants, not user input
     marketplace = JSON.parse(fs.readFileSync(marketplacePath, "utf8"));
   } catch (e) {
     error(`Failed to parse ${marketplacePath}: ${e.message}`);


### PR DESCRIPTION
## Summary

- Fix `nosemgrep` inline comments that used truncated rule IDs, causing suppressions to be silently ignored by semgrep
- All 7 findings are false positives with explanatory comments preserved:
  - `format_detector.py` (3 findings): `is_valid` is a `@dataclass` `bool` field, not a method — `-- dataclass field, not a method`
  - `validate-cross-refs.cjs` (4 findings): `marketplacePath` parameter is only ever called with hardcoded string constants — `-- callers pass hardcoded constants, not user input`

## Test plan

- [ ] Run `mise run security:semgrep` — should show 0 findings (down from 7 in these files)
- [ ] Run `mise run build` — passes cleanly

Generated with [Claude Code](https://claude.com/claude-code)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agent-plugins/blob/main/LICENSE).