### PR TITLE
feat: aws-summary plugin to generate business-ready summaries of AWS launch annoucements

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -29,6 +29,18 @@
       "category": "Full Stack"
     },
     {
+      "name": "aws-summary",
+      "source": {
+        "source": "local",
+        "path": "./plugins/aws-summary"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "News"
+    },
+    {
       "name": "aws-serverless",
       "source": {
         "source": "local",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,6 +49,24 @@
       "version": "1.0.0"
     },
     {
+      "category": "news",
+      "description": "Generate business-ready summaries of latest AWS announcements, blogs, and press releases with category filtering and time ranges.",
+      "keywords": [
+        "aws",
+        "announcements",
+        "blogs",
+        "news",
+        "updates",
+        "summaries",
+        "whats-new",
+        "press-releases"
+      ],
+      "name": "aws-summary",
+      "source": "./plugins/aws-summary",
+      "tags": ["aws", "announcements", "news", "summaries"],
+      "version": "1.0.0"
+    },
+    {
       "category": "development",
       "description": "Design, build, deploy, test, and debug serverless applications with AWS Serverless services.",
       "keywords": [

--- a/plugins/aws-summary/.claude-plugin/plugin.json
+++ b/plugins/aws-summary/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "author": {
+    "name": "AWS Labs"
+  },
+  "description": "Generate business-ready summaries of latest AWS announcements, blogs, and press releases",
+  "homepage": "https://github.com/awslabs/agent-plugins",
+  "keywords": [
+    "aws",
+    "announcements",
+    "blogs",
+    "news",
+    "updates",
+    "summaries",
+    "whats-new"
+  ],
+  "license": "MIT",
+  "name": "aws-summary",
+  "repository": "https://github.com/awslabs/agent-plugins",
+  "version": "1.0.0"
+}

--- a/plugins/aws-summary/.codex-plugin/plugin.json
+++ b/plugins/aws-summary/.codex-plugin/plugin.json
@@ -1,0 +1,43 @@
+{
+  "name": "aws-summary",
+  "version": "1.0.0",
+  "description": "Generate business-ready summaries of latest AWS announcements, blogs, and press releases",
+  "author": {
+    "name": "AWS Labs",
+    "email": "aws-agent-plugins@amazon.com",
+    "url": "https://github.com/awslabs/agent-plugins"
+  },
+  "homepage": "https://github.com/awslabs/agent-plugins",
+  "repository": "https://github.com/awslabs/agent-plugins",
+  "license": "MIT",
+  "keywords": [
+    "aws",
+    "announcements",
+    "blogs",
+    "news",
+    "updates",
+    "summaries",
+    "whats-new",
+    "press-releases"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "AWS Summary",
+    "shortDescription": "Fetch and summarize latest AWS announcements and blogs",
+    "longDescription": "Generate business-ready summaries of AWS announcements, blogs, and press releases with category filtering and time ranges. Output formatted for Slack and email with Unicode bold and emojis.",
+    "defaultPrompt": [
+      "Show me AWS updates from the last 7 days",
+      "Get AWS AI/ML announcements from last 2 weeks",
+      "Summarize recent AWS compute and container updates"
+    ],
+    "developerName": "AWS Labs",
+    "category": "News",
+    "capabilities": [
+      "Read"
+    ],
+    "websiteURL": "https://github.com/awslabs/agent-plugins",
+    "privacyPolicyURL": "https://aws.amazon.com/privacy/",
+    "termsOfServiceURL": "https://aws.amazon.com/service-terms/",
+    "brandColor": "#FF9900"
+  }
+}

--- a/plugins/aws-summary/LICENSE
+++ b/plugins/aws-summary/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 AWS Summary Skill Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/aws-summary/README.md
+++ b/plugins/aws-summary/README.md
@@ -1,0 +1,104 @@
+# AWS Summary Plugin
+
+Generate business-ready summaries of AWS announcements, blogs, and press releases optimized for Slack and email.
+
+## Overview
+
+This plugin fetches the latest AWS announcements from multiple official sources and formats them into concise, business-focused summaries with category grouping, Unicode bold formatting, and emoji icons.
+
+## Skills
+
+- **aws-summary** - Generate summaries of AWS announcements, blogs, and press releases with time range and category filtering
+
+## Data Sources
+
+- AWS What's New feed
+- AWS News Blog
+- AWS Press Releases
+- 8 Category-specific AWS blogs (ML, Compute, Containers, Databases, Storage, Networking, Security, Management)
+
+## Installation
+
+### From Marketplace
+
+```bash
+/plugin marketplace add awslabs/agent-plugins
+/plugin install aws-summary@agent-plugins-for-aws
+```
+
+### Local Development
+
+```bash
+claude --plugin-dir ./plugins/aws-summary
+```
+
+## Usage
+
+### Natural Language Examples
+
+```
+"Show me AWS updates"
+"What's new in AWS last 2 weeks?"
+"AWS AI/ML announcements from last 30 days"
+"Recent compute and container launches"
+"AWS security updates last week"
+```
+
+### Supported Parameters
+
+- **Time range**: 7 days (default), 14 days, 30 days, or any custom number
+- **Categories**: AI/ML, Compute, Containers, Databases, Storage, Networking, Security, DevOps
+
+### Category Filtering
+
+```
+# Single category
+"ai/ml updates"
+"compute announcements"
+
+# Multiple categories
+"ai and compute updates"
+"security, networking, and databases from last 2 weeks"
+```
+
+## Output Format
+
+Generates `aws-summary-YYYY-MM-DD-HHMMSS.md` with:
+
+- **Unicode bold formatting** - Works when pasted into Slack
+- **Emoji icons** - 📢 announcements, 📝 blogs, 🤖 AI/ML, 💻 compute, 📦 containers, etc.
+- **Plain text URLs** - Auto-convert to clickable links in Slack
+- **Category grouping** - Dynamically organized by service area
+- **Business-focused** - Emphasizes "what" and "why it matters" over technical details
+
+## Examples
+
+### All Categories, Last 7 Days
+
+```
+"aws summary"
+```
+
+### Specific Timeframe
+
+```
+"aws updates last 14 days"
+"aws summary 30 days"
+```
+
+### Category-Specific
+
+```
+"latest ai/ml announcements"
+"compute and containers updates"
+"security announcements last 2 weeks"
+```
+
+## Requirements
+
+- Claude Code, Cursor, Kiro, or any AI tool supporting Agent Skills specification
+- WebFetch capability (for retrieving RSS feeds and web content)
+
+## License
+
+MIT

--- a/plugins/aws-summary/README.md
+++ b/plugins/aws-summary/README.md
@@ -96,7 +96,6 @@ Generates `aws-summary-YYYY-MM-DD-HHMMSS.md` with:
 
 ## Requirements
 
-- Claude Code, Cursor, Kiro, or any AI tool supporting Agent Skills specification
 - WebFetch capability (for retrieving RSS feeds and web content)
 
 ## License

--- a/plugins/aws-summary/skills/aws-summary/SKILL.md
+++ b/plugins/aws-summary/skills/aws-summary/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: aws-summary
+description: >
+  Generate business-ready summaries of AWS announcements, blogs, and press releases.
+  Triggers on: "aws summary", "aws updates", "latest AWS news", "what's new in AWS",
+  "AWS announcements", "recent AWS launches". Supports time ranges (7-30 days) and
+  category filtering (AI/ML, Compute, Containers, Databases, Storage, Networking,
+  Security, DevOps). Output formatted for Slack/email with Unicode bold and emojis.
+license: MIT
+metadata:
+  tags: aws, announcements, blogs, news, updates, summaries, whats-new
+---
+
+# AWS Summary Generator
+
+Generate summaries of AWS announcements, blogs, and press releases from a specified time period (default: 7 days).
+
+## Parameters
+
+- **days**: Number of days to look back (default: 7)
+- **category**: Optional category filter (single: "ai/ml" or multiple: "ai/ml, compute" or "ai and security")
+
+## Usage Examples
+
+- Default (all categories, last 7 days): natural language request like "show me AWS updates"
+- Specific timeframe: "aws updates last 14 days" or "aws summary 30 days"
+- Category filter: "ai/ml updates" or "compute and containers announcements"
+- Combined: "last 2 weeks ai and security updates"
+
+## Workflow
+
+### Step 1: Parse Request
+
+Extract parameters from user input:
+
+- Days: Look for numbers followed by "days", "weeks" (convert weeks to days)
+- Category: Extract category keywords (ai, ml, compute, containers, databases, storage, networking, security, devops)
+- If not specified, use defaults (days=7, category=all)
+
+### Step 2: Calculate Cutoff Date
+
+- REQUIRED: Calculate cutoff date = today's date - days parameter
+- Example: If today is April 11, 2026 and days=7, cutoff is April 4, 2026
+
+### Step 3: Fetch Content
+
+- REQUIRED: Use WebFetch tool to retrieve content from ALL sources (see references/sources.md)
+- Fetch in parallel when possible for performance
+- Filter results to include only items published after cutoff date
+
+### Step 4: Filter & Categorize
+
+- Apply announcement filtering (see references/sources.md for rules)
+- If category parameter provided, apply category filter (see references/format.md for normalization)
+- Intelligently categorize all announcements into relevant groups
+- CRITICAL: If specific categories requested, ONLY include those categories in output
+
+### Step 5: Format Output
+
+- Structure content per references/format.md
+- Apply style guidelines from references/style.md
+- Group by category with appropriate emojis
+- Include only categories with announcements
+
+### Step 6: Save & Report
+
+- REQUIRED: Save output to `aws-summary-YYYY-MM-DD-HHMMSS.md` in current working directory
+- Inform user of file location
+- DO NOT include footer or attribution
+
+## Error Handling
+
+### WebFetch Failure
+
+- If source unavailable: Log warning, continue with available sources
+- If ALL sources fail: Report error to user: "Unable to fetch AWS announcements. Check network connection."
+- DO NOT proceed with empty results
+
+### No Results Found
+
+- If zero announcements match filters: Inform user: "No announcements found for [timeframe] [categories]. Try expanding date range or removing category filter."
+- Suggest adjustments: wider date range or different categories
+
+### Invalid Category
+
+- If unrecognized category provided: Show warning with valid category list
+- Proceed with closest match or ask for clarification
+
+## Reference Files
+
+- **references/sources.md** - Complete list of data sources and filtering rules
+- **references/format.md** - Output structure and category normalization
+- **references/style.md** - Writing style and formatting guidelines

--- a/plugins/aws-summary/skills/aws-summary/references/format.md
+++ b/plugins/aws-summary/skills/aws-summary/references/format.md
@@ -1,0 +1,41 @@
+# Output Format
+
+## Category Filtering (CRITICAL)
+
+When `category` parameter is provided:
+
+- ONLY include announcements from the specified category/categories
+- Single category example: "ai/ml" → only AI/ML announcements
+- Multiple categories example: "ai/ml, compute" or "ai and compute" → only AI/ML and Compute
+- DO NOT include announcements from other categories when specific categories are requested
+- If no category is specified, include all categories
+
+## Category Normalization
+
+Recognize common variations:
+
+- **AI/ML**: "ai", "ml", "ai/ml", "machine learning", "artificial intelligence", "generative ai", "genai"
+- **Compute**: "compute", "ec2", "lambda", "serverless"
+- **Containers**: "containers", "ecs", "eks", "kubernetes", "docker"
+- **Databases**: "database", "databases", "db", "rds", "dynamodb"
+- **Storage**: "storage", "s3"
+- **Networking**: "networking", "network", "vpc", "cloudfront"
+- **Security**: "security", "iam", "cognito"
+- **DevOps**: "devops", "cicd", "ci/cd", "management", "governance", "observability", "monitoring"
+
+## Structure
+
+1. **Dynamically group by category**: Analyze all announcements and intelligently group them (AI/ML, Compute, Containers, Databases, Storage, Networking, Security, DevOps, Analytics, etc.)
+2. **Category sections**: Use appropriate emoji for each category (e.g., 🤖 AI/ML, 💻 Compute, 📦 Containers, 💾 Databases, 🔐 Security)
+3. **For each item include**:
+   - Clear title and business-focused description
+   - Full URL as plain text (NOT markdown links - Slack auto-converts)
+   - Use 📝 for blog posts, 📢 for "What's New" announcements
+4. **Keep descriptions concise** - focus on business impact, not technical details
+5. **Only show categories with announcements** - omit empty categories
+
+## File Output
+
+- Save to: `aws-summary-YYYY-MM-DD-HHMMSS.md` (use current date/time)
+- Location: current working directory
+- DO NOT include footer or attribution line (e.g., "Generated with...")

--- a/plugins/aws-summary/skills/aws-summary/references/sources.md
+++ b/plugins/aws-summary/skills/aws-summary/references/sources.md
@@ -1,0 +1,34 @@
+# Data Sources
+
+ALWAYS fetch from ALL sources below:
+
+## Primary Sources
+
+1. **What's New feed**: https://aws.amazon.com/about-aws/whats-new/recent/feed/
+2. **AWS News Blog**: https://aws.amazon.com/blogs/aws/feed/
+3. **Press releases**: https://press.aboutamazon.com/aws
+
+## Category-Specific Blogs
+
+1. **AWS Machine Learning Blog**: https://aws.amazon.com/blogs/machine-learning/feed/
+2. **AWS Compute Blog**: https://aws.amazon.com/blogs/compute/feed/
+3. **AWS Containers Blog**: https://aws.amazon.com/blogs/containers/feed/
+4. **AWS Database Blog**: https://aws.amazon.com/blogs/database/feed/
+5. **AWS Storage Blog**: https://aws.amazon.com/blogs/storage/feed/
+6. **AWS Networking Blog**: https://aws.amazon.com/blogs/networking-and-content-delivery/feed/
+7. **AWS Security Blog**: https://aws.amazon.com/blogs/security/feed/
+8. **AWS Management & Governance Blog**: https://aws.amazon.com/blogs/mt/feed/
+
+## Filtering Rules
+
+Include ONLY items that match:
+
+- Published after the calculated cutoff date
+- Blog posts with announcement indicators:
+  - Title contains: "Announcing", "launches", "introduces", "Now Available", "Now Generally Available", "GA"
+  - OR tagged/categorized as: "Launch", "Announcement", "Announcements"
+
+Exclude:
+
+- Tutorials and how-to guides (unless announcing a new feature)
+- Educational content without product launches

--- a/plugins/aws-summary/skills/aws-summary/references/style.md
+++ b/plugins/aws-summary/skills/aws-summary/references/style.md
@@ -1,0 +1,28 @@
+# Style Guidelines
+
+## Formatting Rules
+
+- **Plain text format** with visual hierarchy through line breaks and emojis
+- **DO NOT use markdown formatting** (asterisks, underscores) - doesn't work when pasted into Slack
+- **Use Unicode bold characters** for titles:
+  - Main title: Use bold Unicode
+  - Section titles: Use bold Unicode (e.g., 𝗔𝗜/𝗠𝗟)
+  - Announcement titles: Use bold Unicode for brand names (e.g., 𝗔𝗪𝗦 instead of AWS, 𝗔𝗺𝗮𝘇𝗼𝗻 instead of Amazon)
+- **URLs as plain text** - Slack auto-converts to clickable links
+
+## Writing Style
+
+- **Business-ready language** - suitable for sharing with business stakeholders
+- **Focus on "what" and "why it matters"** - not technical implementation details
+- **Highlight competitive advantages and business value**
+- **Professional tone**
+- **Easy to copy-paste** directly into Slack or email
+
+## Description Guidelines
+
+Keep descriptions concise:
+
+- 1-2 sentences maximum
+- Business impact over technical details
+- Clear value proposition
+- Avoid jargon when possible


### PR DESCRIPTION
#### Summary

Add aws-summary plugin to generate business-ready summaries of AWS announcements, blogs, and press releases.    

#### Related

Addresses need for easily digestible AWS news summaries for AWS users

#### Changes

 New Plugin: aws-summary                                                                            
  - Auto-triggers on user requests for AWS updates, announcements, or news
  - Fetches from multiple sources:                                                                   
    - AWS What's New feed                                                                          
    - AWS News Blog                                                                                  
    - Category-specific blogs (ML, Compute, Containers, Databases, Storage, Networking, Security,    
  DevOps)                                                                                            
  - Features:                                                                                        
    - Configurable time ranges (7-30 days, default: 7 days)                                          
    - Category filtering (single or multiple categories)                                             
    - Intelligent categorization with relevant emojis                                                
    - Business-focused descriptions highlighting impact and value                                    
    - Plain text format optimized for Slack/email (Unicode bold, auto-linkable URLs)                 
  - Output saved as timestamped markdown file in current directory                                   
                                                                                                     
  Files Added:                                                                                       
  - plugins/aws-summary/.claude-plugin/plugin.json - Plugin manifest                                 
  - plugins/aws-summary/.codex-plugin/plugin.json - Codex plugin manifest                            
  - plugins/aws-summary/skills/aws-summary/SKILL.md - Main skill definition and workflow             
  - plugins/aws-summary/skills/aws-summary/references/ - Sources, format, and style guidelines       
  - plugins/aws-summary/README.md - Plugin documentation                                             
  - plugins/aws-summary/LICENSE - MIT license                                                        
  - Updated .claude-plugin/marketplace.json - Added plugin entry                                     
  - Updated .claude/settings.json - Enabled plugin for testing    
#### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agent-plugins/blob/main/LICENSE).
