### PR TITLE
fix(codeowners): remove admins requirement from sagemaker-ai plugin path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,7 +36,7 @@ plugins/aws-serverless              @awslabs/agent-plugins-admins @awslabs/agent
 plugins/databases-on-aws            @awslabs/agent-plugins-admins @awslabs/agent-plugins-maintainers  @awslabs/agent-plugins-dsql
 plugins/deploy-on-aws               @awslabs/agent-plugins-admins @awslabs/agent-plugins-maintainers  @awslabs/agent-plugins-deploy-on-aws
 plugins/migration-to-aws            @awslabs/agent-plugins-admins @awslabs/agent-plugins-maintainers  @awslabs/agent-plugins-migrate-to-aws
-plugins/sagemaker-ai                @awslabs/agent-plugins-admins @awslabs/agent-plugins-maintainers  @awslabs/agent-plugins-sagemaker-ai
+plugins/sagemaker-ai                @awslabs/agent-plugins-sagemaker-ai
 
 ## Evals (match plugin ownership)
 


### PR DESCRIPTION
Removes `@awslabs/agent-plugins-admins` and '@awslabs/agent-plugins-maintainers' from the `plugins/sagemaker-ai` CODEOWNERS entry so the sagemaker-ai team can self-approve PRs without requiring additional sign-off on changes. 
 
 #### Changes 
 
 - `plugins/sagemaker-ai` code ownership updated from: 
 `@awslabs/agent-plugins-admins @awslabs/agent-plugins-maintainers @awslabs/agent-plugins-sagemaker-ai` 
 to: 
 `@awslabs/agent-plugins-sagemaker-ai` 
 
 #### Acknowledgment 
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agent-plugins/blob/main/LICENSE).