### PR TITLE
chore: exclude ./.tmp and ./node_modules from Bandit security scan

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -106,7 +106,7 @@ run = "uv run tools/init-skill.py"
 [tasks."security:bandit"]
 description = "Run Bandit"
 run = [
-  "bandit -r ."
+  "bandit -r . -x ./.tmp,./node_modules",
 ]
 
 [tasks."security:semgrep"]


### PR DESCRIPTION
## Summary

- Scope the \`security:bandit\` mise task with \`-x ./.tmp,./node_modules\`
- Matches how other scanners (gitleaks, semgrep) already treat these dirs via their respective ignore files

## Why

Bandit currently scans the entire repo recursively. Two paths are noisy:

- **\`./.tmp/\`** is already gitignored and used for per-developer scratch code (one-shot data-seeding scripts, local evaluation fixtures, etc.). These scripts often use \`random\` and \`subprocess\` for legitimate local tasks, but Bandit surfaces them as Low-severity findings that fail the build.
- **\`./node_modules/\`** is gitignored and should never be scanned — it's third-party code not part of this repo's security surface.

## Test plan

- [x] \`mise run build\` passes locally with the exclusion applied
- [x] Confirmed \`./.tmp/\` stays hidden from git (still in .gitignore) — scan behavior change only
- [x] No other scanner behavior affected

Split out of #141 because \`mise.toml\` is an admin-only path per CODEOWNERS; the main PR's dsql-group approvals were blocked on this one-line admin-scoped change.

Generated with [Claude Code](https://claude.com/claude-code)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agent-plugins/blob/main/LICENSE).