### PR TITLE
chore(codebase-documentor-for-aws): bump version to 1.0.0

### DIFF
--- a/plugins/codebase-documentor-for-aws/.claude-plugin/plugin.json
+++ b/plugins/codebase-documentor-for-aws/.claude-plugin/plugin.json
@@ -20,5 +20,5 @@
   "license": "Apache-2.0",
   "name": "codebase-documentor-for-aws",
   "repository": "https://github.com/awslabs/agent-plugins",
-  "version": "0.1.0"
+  "version": "1.0.0"
 }

--- a/plugins/codebase-documentor-for-aws/.codex-plugin/plugin.json
+++ b/plugins/codebase-documentor-for-aws/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-documentor-for-aws",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Analyze codebases to generate structured technical documentation with source-of-truth citations. Optimized for AWS workloads using CDK, CloudFormation, and Terraform.",
   "author": {
     "name": "Amazon Web Services",


### PR DESCRIPTION
## Summary

- Bumps `codebase-documentor-for-aws` plugin version from `0.1.0` to `1.0.0` in both `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json`.
- Aligns the plugin with the marketplace convention where initial stable releases are versioned `1.0.0`.

## Why

The plugin was merged in #138 at `0.1.0`, which in semver signals a pre-stable / breaking-changes-expected release. Every other first-release plugin in this marketplace ships at `1.0.0`:

| Plugin | Version |
| --- | --- |
| `amazon-location-service` | 1.0.0 |
| `aws-amplify` | 1.0.0 |
| `aws-serverless` | 1.0.0 |
| `databases-on-aws` | 1.0.0 |
| `sagemaker-ai` | 1.1.0 |
| `deploy-on-aws` | 1.2.0 |
| **`codebase-documentor-for-aws`** | **0.1.0** ← fixing this |

The plugin is functionally complete and ready for general use, so promoting to `1.0.0` reflects actual maturity and keeps the marketplace consistent.

## Test plan

- [x] `mise run lint:manifests` — all manifests valid
- [x] `mise run lint:cross-refs` — no errors
- [x] `mise run fmt:check` — passes
- [x] `mise run build` — full build passes (exit 0)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agent-plugins/blob/main/LICENSE).