### PR TITLE
fix(sagemaker-ai): quote model-evaluation skill description to fix YAML parse error

### DIFF
--- a/plugins/sagemaker-ai/skills/model-evaluation/SKILL.md
+++ b/plugins/sagemaker-ai/skills/model-evaluation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: model-evaluation
-description: Generates python code that evaluates SageMaker models. Supports two evaluation types: LLM-as-Judge and Custom Scorer. Use when the user says "evaluate my model", "test model performance", "how did my model perform", "compare models", or other similar requests.
+description: 'Generates python code that evaluates SageMaker models. Supports two evaluation types: LLM-as-Judge and Custom Scorer. Use when the user says "evaluate my model", "test model performance", "how did my model perform", "compare models", or other similar requests.'
 metadata:
   version: "2.0.0"
 ---


### PR DESCRIPTION
Fixes a YAML frontmatter parse error in the `sagemaker-ai` plugin's `model-evaluation` skill.

#### Related

Same class of fix as #10. No existing issue or PR addresses this skill.

#### Changes

The `description` in `plugins/sagemaker-ai/skills/model-evaluation/SKILL.md` is an unquoted YAML plain scalar that contains a colon followed by a space (`two evaluation types: LLM-as-Judge`). A YAML parser treats that colon as a mapping indicator inside a block scalar and rejects the frontmatter with `mapping values are not allowed here`.

Effect: the skill loads with empty metadata (the `name`, `description`, and `metadata.version` fields are silently dropped), so the skill does not trigger, and `claude plugin validate plugins/sagemaker-ai` fails with:

```
✘ frontmatter: YAML frontmatter failed to parse: YAML Parse error: Unexpected token.
  At runtime this skill loads with empty metadata (all frontmatter fields silently dropped).
```

Fix: wrap the `description` value in single quotes. This turns it into a valid quoted scalar while preserving the text verbatim, including the inner double quotes and the colon. The change is a single line; no wording is altered.

I scanned all 28 `SKILL.md` files in the repo with a YAML parser; this was the only one that failed to parse. After the change, `claude plugin validate plugins/sagemaker-ai` reports `✔ Validation passed`.

#### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agent-plugins/blob/main/LICENSE).
