### PR TITLE
fix: Make SKILL.md 300-line threshold a warning, not a CI error

### DIFF
--- a/tools/markdownlint-skill-length.cjs
+++ b/tools/markdownlint-skill-length.cjs
@@ -2,11 +2,14 @@
  * Custom markdownlint rule: skill-length
  * Validates SKILL.md files don't exceed length limits.
  *
+ * Philosophy: SKILL.md is loaded into the agent's context window on every
+ * invocation. Keep it lean — big ideas and routing only. Push detailed
+ * instructions, examples, and reference material into sub-files under
+ * references/ so the agent loads them on demand.
+ *
  * Limits:
- * - Max 500 lines (error)
- * - Max 8000 words (error)
- * - Recommended 300 lines (warning via info)
- * - Recommended 5000 words (warning via info)
+ * - Hard error at 500 lines / 8000 words (blocks CI)
+ * - Warning at 300 lines / 5000 words (informational, does not block CI)
  */
 
 "use strict";
@@ -38,34 +41,35 @@ module.exports = {
     const content = lines.join("\n");
     const wordCount = content.split(/\s+/).filter(Boolean).length;
 
-    // Check line count
+    // Check line count — only hard limit blocks CI
     if (totalLines > MAX_LINES) {
       onError({
         lineNumber: 1,
         detail: `Line count: ${totalLines} (max: ${MAX_LINES}). Move detailed content to references/ subdirectory.`,
-        context: `${totalLines} lines`,
+        context: `${totalLines} lines (error)`,
       });
     } else if (totalLines > WARNING_LINES) {
-      onError({
-        lineNumber: 1,
-        detail: `Line count: ${totalLines} (recommended: <${WARNING_LINES}). Consider moving content to references/.`,
-        context: `${totalLines} lines (warning)`,
-      });
+      // Advisory only — does not block CI. Aim to stay under 300 lines by
+      // keeping only big ideas and routing in SKILL.md and pushing details
+      // into reference files.
+      console.warn(
+        `  ⚠️  ${params.name}: ${totalLines} lines (target: <${WARNING_LINES}). ` +
+        `Consider moving detailed content to references/.`
+      );
     }
 
-    // Check word count
+    // Check word count — only hard limit blocks CI
     if (wordCount > MAX_WORDS) {
       onError({
         lineNumber: 1,
         detail: `Word count: ${wordCount} (max: ${MAX_WORDS}). Move detailed content to references/ subdirectory.`,
-        context: `${wordCount} words`,
+        context: `${wordCount} words (error)`,
       });
     } else if (wordCount > WARNING_WORDS) {
-      onError({
-        lineNumber: 1,
-        detail: `Word count: ${wordCount} (recommended: <${WARNING_WORDS}). Consider moving content to references/.`,
-        context: `${wordCount} words (warning)`,
-      });
+      console.warn(
+        `  ⚠️  ${params.name}: ${wordCount} words (target: <${WARNING_WORDS}). ` +
+        `Consider moving detailed content to references/.`
+      );
     }
   },
 };


### PR DESCRIPTION
## Problem

The custom markdownlint rule `SKILL001` calls `onError` for both the 500-line hard limit and the 300-line soft target. Since markdownlint has no severity levels, both block CI. This forces skill authors to aggressively trim content or work around the linter, even when their SKILL.md is well under the 500-line hard limit.

## Fix

- **500 lines / 8000 words** → `onError` (blocks CI)
- **300 lines / 5000 words** → `console.warn` (informational, does not block CI)

The `validate-size.py` script already uses this same semantic (error at 500, warning at 300).

## Design Guidance (added as code comment)

SKILL.md is loaded into the agent's context window on every invocation. Keep it lean:
- Big ideas and routing only at the top level
- Push detailed instructions, examples, and reference material into `references/` sub-files
- The agent loads reference files on demand rather than flooding its context window

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agent-plugins/blob/main/LICENSE).