### PR TITLE
fix(sagemaker-ai): update Claude Code install instructions

### DIFF
--- a/plugins/sagemaker-ai/README.md
+++ b/plugins/sagemaker-ai/README.md
@@ -42,13 +42,15 @@ This plugin brings deep AWS AI/ML expertise directly into your coding assistant,
 Run in your terminal:
 
 ```
-claude plugin install sagemaker-ai@claude-plugins-official
+claude plugins marketplace add awslabs/agent-plugins
+claude plugins install sagemaker-ai@agent-plugins-for-aws
 ```
 
 Or if you're already inside Claude Code, run:
 
 ```
-/plugin install sagemaker-ai@claude-plugins-official
+/plugin marketplace add awslabs/agent-plugins
+/plugin install sagemaker-ai@agent-plugins-for-aws
 ```
 
 ### Cursor


### PR DESCRIPTION
Updates the Claude Code installation instructions to use the agent-plugins-for-aws marketplace.

### Changes
- Updated Claude Code install section to use 2-step marketplace add + install from agent-plugins-for-aws

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agent-plugins/blob/main/LICENSE).