### PR TITLE
[sagemaker-ai] Add MTRL fine-tuning technique skill

### DIFF
--- a/plugins/sagemaker-ai/skills/dataset-evaluation/SKILL.md
+++ b/plugins/sagemaker-ai/skills/dataset-evaluation/SKILL.md
@@ -29,11 +29,14 @@ Follow the workflow shown below. Locate the dataset, check the file type, and re
 4. **Summarize Results**: Tell the user if their data is ready
    - Examine the output of format_detector and compare to the known strategy and model
    - **Important: training datasets and evaluation datasets have different format requirements.**
-     - **Training datasets** must match the fine-tuning strategy format (SFT, DPO, RLVR) per `references/strategy_data_requirements.md`
+     - **Training datasets** must match the fine-tuning strategy format (SFT, DPO, RLVR, or MTRL) per `references/strategy_data_requirements.md`
      - **Evaluation datasets** (for model evaluation) must match one of the [SageMaker evaluation dataset formats](https://docs.aws.amazon.com/sagemaker/latest/dg/model-customize-evaluation-dataset-formats.html).
    - Report back to the user if their current dataset is valid for its intended purpose
    - Warn the user if their dataset is valid, but for a different strategy or model
    - Warn the user if their dataset is not valid for any strategy/model pair
+   - **MTRL warning rules** (apply in addition to the warnings above):
+     - WHEN format_detector reports `mtrl_parquet` (or otherwise classifies the dataset as MTRL-compatible) AND the selected technique is not `mtrl`: warn the user that the dataset matches the MTRL format and ask whether they intended to use MTRL. Do not proceed until the user confirms the technique.
+     - WHEN format_detector reports a non-MTRL format AND the selected technique is `mtrl`: warn the user that the dataset does not match the MTRL format (a `prompt`-column Parquet file is preferred; JSONL/JSON/CSV with a `prompt` column are also accepted) and offer to invoke the `dataset-transformation` skill to convert it. If the user accepts, hand off to `dataset-transformation` with the MTRL target format.
 
 ## Messages to the User
 

--- a/plugins/sagemaker-ai/skills/dataset-evaluation/references/strategy_data_requirements.md
+++ b/plugins/sagemaker-ai/skills/dataset-evaluation/references/strategy_data_requirements.md
@@ -171,3 +171,31 @@ The format is the same as SFT for the first N-1 turns. The final assistant turn 
   }
 }
 ```
+
+## MTRL Data Format
+
+MTRL (Multi-Turn Reinforcement Learning) datasets define the prompts that drive rollouts against your agent environment. The dataset only needs to provide prompts; rewards come from the environment, not the dataset.
+
+### Required column
+
+- A `prompt` column containing string values. The service uses the column literally named `prompt`. If no `prompt` column exists, the first column is treated as the prompt column (per the SageMaker SDK).
+
+### Supported file formats
+
+In order of preference:
+
+1. Parquet (`.parquet`) — preferred
+2. JSONL (`.jsonl`)
+3. JSON array (`.json`)
+4. CSV (`.csv`)
+
+### Format-agnostic prompt content
+
+The service does not parse the prompt string. Whatever you put into the `prompt` column is forwarded verbatim to your agent environment, which is responsible for parsing. For structured or agentic prompts (conversation history, tool configs, environment metadata), JSON-encode the structure into one string per record:
+
+```python
+import json
+
+task_data = {"prompt": [...], "env_class": "search", ...}
+data = {"prompt": [json.dumps(task_data)]}
+```

--- a/plugins/sagemaker-ai/skills/dataset-evaluation/scripts/format_detector.py
+++ b/plugins/sagemaker-ai/skills/dataset-evaluation/scripts/format_detector.py
@@ -2,9 +2,14 @@
 
 This module provides functionality to detect and validate JSONL file formats
 stored in S3. It samples the first 1MB of a file to determine the format type
-across 11 supported formats: Nova SFT, Nova DPO, Nova RLVR, GPT-OSS SFT,
+across 12 supported formats: Nova SFT, Nova DPO, Nova RLVR, GPT-OSS SFT,
 GPT-OSS DPO, Open Weights SFT, Open Weights SFT Conv, Open Weights DPO,
-Verl, Verl Legacy, and SageMaker Eval.
+Verl, Verl Legacy, SageMaker Eval, and MTRL Parquet.
+
+The ``MTRL_PARQUET`` label is the unified identifier for any MTRL-compatible
+container (Parquet, JSONL, JSON, or CSV) that carries the agentic multi-turn
+RL schema. Downstream skills only need to ask "is this MTRL-shaped data?" so
+a single label is used regardless of the underlying file extension.
 
 Usage:
     result = detect_format("s3://my-bucket/data.jsonl")
@@ -15,6 +20,8 @@ Usage:
 from dataclasses import dataclass
 from enum import Enum
 import boto3
+import csv
+import io
 import json
 import logging
 
@@ -36,6 +43,7 @@ class FormatType(Enum):
     VERL = "verl"
     VERL_LEGACY = "verl_legacy"
     SAGEMAKER_EVAL = "sagemaker_eval"
+    MTRL_PARQUET = "mtrl_parquet"
     UNKNOWN = "unknown"
 
 
@@ -156,6 +164,498 @@ def _sample_s3_file(s3_uri: str, sample_size_bytes: int, s3_client=None) -> list
     lines = [line for line in complete_text.split("\n") if line]
     
     return lines
+
+
+def _read_first_4_bytes_local(file_path: str) -> bytes:
+    """Read the first 4 bytes of a local file.
+
+    Args:
+        file_path: Path to local file
+
+    Returns:
+        First 4 bytes of the file (may be shorter if the file is smaller)
+
+    Raises:
+        FileNotFoundError: If the file doesn't exist
+        IOError: If the file can't be read
+    """
+    logger.debug("Reading first 4 bytes of local file: %s", file_path)
+    with open(file_path, "rb") as f:
+        return f.read(4)
+
+
+def _read_last_4_bytes_local(file_path: str) -> bytes:
+    """Read the last 4 bytes of a local file.
+
+    Used as a Parquet footer sanity check; valid Parquet containers end in
+    the 4-byte magic ``PAR1``.
+
+    Args:
+        file_path: Path to local file
+
+    Returns:
+        Last 4 bytes of the file (may be shorter if the file is smaller
+        than 4 bytes)
+
+    Raises:
+        FileNotFoundError: If the file doesn't exist
+        IOError: If the file can't be read
+    """
+    logger.debug("Reading last 4 bytes of local file: %s", file_path)
+    with open(file_path, "rb") as f:
+        f.seek(0, 2)  # Seek to end
+        file_size = f.tell()
+        if file_size < 4:
+            f.seek(0)
+            return f.read()
+        f.seek(file_size - 4)
+        return f.read(4)
+
+
+def _read_first_4_bytes_s3(s3_uri: str, s3_client=None) -> bytes:
+    """Read the first 4 bytes of an S3 object via a Range GET.
+
+    Args:
+        s3_uri: S3 URI in format ``s3://bucket/key``
+        s3_client: Optional boto3 S3 client to reuse
+
+    Returns:
+        First 4 bytes of the object (may be shorter if the object is smaller)
+
+    Raises:
+        ValueError: If the S3 URI is invalid
+        botocore.exceptions.ClientError: If S3 access fails
+    """
+    logger.debug("Reading first 4 bytes of S3 object: %s", s3_uri)
+    if not s3_uri.startswith("s3://"):
+        raise ValueError(f"Invalid S3 URI: must start with 's3://' (got: {s3_uri})")
+
+    uri_without_prefix = s3_uri[5:]
+    parts = uri_without_prefix.split("/", 1)
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        raise ValueError(f"Invalid S3 URI: must contain bucket and key (got: {s3_uri})")
+
+    bucket, key = parts
+    client = s3_client or boto3.client("s3")
+    response = client.get_object(Bucket=bucket, Key=key, Range="bytes=0-3")
+    return response["Body"].read()
+
+
+def _detect_parquet(file_path: str, s3_client=None) -> FormatDetectionResult:
+    """Detect a Parquet file by checking the ``PAR1`` magic bytes.
+
+    Reads the first four bytes (via a local read or an S3 ``Range`` GET) and
+    compares them to ``b"PAR1"``. For local files, also verifies the trailing
+    four bytes as a sanity check, since valid Parquet containers end with the
+    same magic.
+
+    Args:
+        file_path: S3 URI (``s3://bucket/key``) or local file path
+        s3_client: Optional boto3 S3 client to reuse (ignored for local files)
+
+    Returns:
+        FormatDetectionResult with ``format_type=MTRL_PARQUET``. ``is_valid``
+        is ``True`` when the magic bytes match (and, for local files, the
+        footer also matches); otherwise ``False`` with a single
+        ``invalid_structure`` error.
+    """
+    is_s3 = file_path.startswith("s3://")
+
+    if is_s3:
+        header = _read_first_4_bytes_s3(file_path, s3_client=s3_client)
+    else:
+        header = _read_first_4_bytes_local(file_path)
+
+    # Empty-file handling: a 0-byte file cannot be a valid Parquet container.
+    if not header:
+        logger.debug("Parquet detection: empty file %s", file_path)
+        return FormatDetectionResult(
+            format_type=FormatType.MTRL_PARQUET,
+            is_valid=False,
+            lines_sampled=0,
+            errors=[ValidationError(
+                line_number=0,
+                error_type="invalid_structure",
+                message="File has .parquet extension but is empty",
+            )],
+            confidence=ConfidenceLevel.NONE,
+        )
+
+    if header != b"PAR1":
+        logger.debug("Parquet detection: header mismatch for %s (got %r)", file_path, header)
+        return FormatDetectionResult(
+            format_type=FormatType.MTRL_PARQUET,
+            is_valid=False,
+            lines_sampled=0,
+            errors=[ValidationError(
+                line_number=0,
+                error_type="invalid_structure",
+                message="File has .parquet extension but does not start with PAR1 magic bytes",
+            )],
+            confidence=ConfidenceLevel.NONE,
+        )
+
+    # For local files, sanity-check the trailing PAR1 footer.
+    if not is_s3:
+        footer = _read_last_4_bytes_local(file_path)
+        if footer != b"PAR1":
+            logger.debug("Parquet detection: footer mismatch for %s (got %r)", file_path, footer)
+            return FormatDetectionResult(
+                format_type=FormatType.MTRL_PARQUET,
+                is_valid=False,
+                lines_sampled=0,
+                errors=[ValidationError(
+                    line_number=0,
+                    error_type="invalid_structure",
+                    message="File starts with PAR1 magic bytes but does not end with PAR1; not a valid Parquet container",
+                )],
+                confidence=ConfidenceLevel.NONE,
+            )
+
+    logger.debug("Parquet detection: valid PAR1 container at %s", file_path)
+    return FormatDetectionResult(
+        format_type=FormatType.MTRL_PARQUET,
+        is_valid=True,
+        lines_sampled=0,
+        errors=[],
+        confidence=ConfidenceLevel.HIGH,
+    )
+
+
+def _read_text_sample_local(file_path: str, sample_size: int) -> str:
+    """Read up to ``sample_size`` bytes from a local file and decode as UTF-8.
+
+    Unlike ``_sample_local_file``, no newline truncation is applied, so the
+    sample can be fed directly into ``json.loads`` or ``csv.reader``.
+
+    Args:
+        file_path: Path to local file
+        sample_size: Maximum bytes to read
+
+    Returns:
+        Decoded UTF-8 text (may be empty if the file is empty)
+
+    Raises:
+        FileNotFoundError: If the file doesn't exist
+        IOError: If the file can't be read
+        UnicodeDecodeError: If the bytes are not valid UTF-8
+    """
+    logger.debug("Reading raw text sample from local file: %s", file_path)
+    with open(file_path, "rb") as f:
+        data = f.read(sample_size)
+    return data.decode("utf-8") if data else ""
+
+
+def _read_text_sample_s3(s3_uri: str, sample_size_bytes: int, s3_client=None) -> str:
+    """Read up to ``sample_size_bytes`` from an S3 object and decode as UTF-8.
+
+    Args:
+        s3_uri: S3 URI in format ``s3://bucket/key``
+        sample_size_bytes: Number of bytes to sample
+        s3_client: Optional boto3 S3 client to reuse
+
+    Returns:
+        Decoded UTF-8 text (may be empty if the object is empty)
+
+    Raises:
+        ValueError: If the S3 URI is invalid
+        botocore.exceptions.ClientError: If S3 access fails
+    """
+    logger.debug("Reading raw text sample from S3 object: %s (%d bytes)", s3_uri, sample_size_bytes)
+    if not s3_uri.startswith("s3://"):
+        raise ValueError(f"Invalid S3 URI: must start with 's3://' (got: {s3_uri})")
+
+    uri_without_prefix = s3_uri[5:]
+    parts = uri_without_prefix.split("/", 1)
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        raise ValueError(f"Invalid S3 URI: must contain bucket and key (got: {s3_uri})")
+
+    bucket, key = parts
+    client = s3_client or boto3.client("s3")
+    range_header = f"bytes=0-{sample_size_bytes - 1}"
+    response = client.get_object(Bucket=bucket, Key=key, Range=range_header)
+    data = response["Body"].read()
+    return data.decode("utf-8") if data else ""
+
+
+def _read_text_sample(file_path: str, sample_size_bytes: int, s3_client=None) -> str:
+    """Read raw text from either a local path or an S3 URI."""
+    if file_path.startswith("s3://"):
+        return _read_text_sample_s3(file_path, sample_size_bytes, s3_client=s3_client)
+    return _read_text_sample_local(file_path, sample_size_bytes)
+
+
+def _is_mtrl_jsonl_record(record) -> bool:
+    """Return True iff ``record`` is a single-key dict whose key is ``prompt``.
+
+    Per design Property 2 / R3.3, an MTRL-compatible JSONL record has exactly
+    one key, that key is exactly ``"prompt"``, and the value is a string. This
+    is intentionally narrow so that any JSONL file that classifies as one of
+    the existing 11 formats is left untouched (R11.2).
+    """
+    if not isinstance(record, dict):
+        return False
+    if len(record) != 1:
+        return False
+    if "prompt" not in record:
+        return False
+    return isinstance(record["prompt"], str)
+
+
+def _detect_json_array(file_path: str, sample_size_bytes: int, s3_client=None) -> FormatDetectionResult:
+    """Detect an MTRL-compatible JSON-array file.
+
+    Classifies as ``MTRL_PARQUET`` when ``json.loads`` returns a non-empty list
+    whose first element is a dict containing a ``prompt`` key, or a dict with
+    exactly one string-typed column (the "first column is the prompt column"
+    fallback per the SageMaker SDK).
+    """
+    try:
+        text = _read_text_sample(file_path, sample_size_bytes, s3_client=s3_client)
+    except UnicodeDecodeError as e:
+        return FormatDetectionResult(
+            format_type=FormatType.MTRL_PARQUET,
+            is_valid=False,
+            lines_sampled=0,
+            errors=[ValidationError(
+                line_number=0,
+                error_type="parse_error",
+                message=f"File has .json extension but is not valid UTF-8: {e}",
+            )],
+            confidence=ConfidenceLevel.NONE,
+        )
+
+    if not text:
+        return FormatDetectionResult(
+            format_type=FormatType.MTRL_PARQUET,
+            is_valid=False,
+            lines_sampled=0,
+            errors=[ValidationError(
+                line_number=0,
+                error_type="invalid_structure",
+                message="File has .json extension but is empty",
+            )],
+            confidence=ConfidenceLevel.NONE,
+        )
+
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as primary_error:
+        # Tolerant retry: when ``sample_size_bytes`` is smaller than the file,
+        # the slice may end mid-array. Try once with a trailing ``]`` to close
+        # an open list. If that also fails, surface the original parse error.
+        try:
+            parsed = json.loads(text + "]")
+        except json.JSONDecodeError:
+            return FormatDetectionResult(
+                format_type=FormatType.MTRL_PARQUET,
+                is_valid=False,
+                lines_sampled=0,
+                errors=[ValidationError(
+                    line_number=0,
+                    error_type="parse_error",
+                    message=f"Invalid JSON: {primary_error}",
+                )],
+                confidence=ConfidenceLevel.NONE,
+            )
+
+    if not isinstance(parsed, list):
+        return FormatDetectionResult(
+            format_type=FormatType.MTRL_PARQUET,
+            is_valid=False,
+            lines_sampled=0,
+            errors=[ValidationError(
+                line_number=0,
+                error_type="invalid_structure",
+                message=f"JSON file must contain a top-level array, got {type(parsed).__name__}",
+            )],
+            confidence=ConfidenceLevel.NONE,
+        )
+
+    if not parsed:
+        return FormatDetectionResult(
+            format_type=FormatType.MTRL_PARQUET,
+            is_valid=False,
+            lines_sampled=0,
+            errors=[ValidationError(
+                line_number=0,
+                error_type="invalid_structure",
+                message="JSON array is empty",
+            )],
+            confidence=ConfidenceLevel.NONE,
+        )
+
+    first = parsed[0]
+    if not isinstance(first, dict) or not first:
+        return FormatDetectionResult(
+            format_type=FormatType.MTRL_PARQUET,
+            is_valid=False,
+            lines_sampled=len(parsed),
+            errors=[ValidationError(
+                line_number=1,
+                error_type="invalid_structure",
+                message="First record in JSON array must be a non-empty object",
+            )],
+            confidence=ConfidenceLevel.NONE,
+        )
+
+    # Accept either an explicit ``prompt`` column with a string value, or a
+    # single-column object whose value is a string (treated as the prompt
+    # column per the SageMaker SDK's fallback).
+    has_prompt_string = isinstance(first.get("prompt"), str)
+    is_single_string_column = len(first) == 1 and isinstance(next(iter(first.values())), str)
+
+    if has_prompt_string or is_single_string_column:
+        logger.debug("JSON array detection: MTRL-compatible at %s", file_path)
+        return FormatDetectionResult(
+            format_type=FormatType.MTRL_PARQUET,
+            is_valid=True,
+            lines_sampled=len(parsed),
+            errors=[],
+            confidence=ConfidenceLevel.HIGH,
+        )
+
+    return FormatDetectionResult(
+        format_type=FormatType.MTRL_PARQUET,
+        is_valid=False,
+        lines_sampled=len(parsed),
+        errors=[ValidationError(
+            line_number=1,
+            error_type="schema_mismatch",
+            message="JSON array's first record has no string 'prompt' column and is not a single-string-column object",
+        )],
+        confidence=ConfidenceLevel.NONE,
+    )
+
+
+def _detect_csv(file_path: str, sample_size_bytes: int, s3_client=None) -> FormatDetectionResult:
+    """Detect an MTRL-compatible CSV file.
+
+    Classifies as ``MTRL_PARQUET`` when the header row has at least one column
+    AND either contains a ``prompt`` column, or (when no ``prompt`` column
+    exists) the first column's first data value is a string (per the
+    SageMaker SDK's "first column is the prompt column" fallback).
+    """
+    try:
+        text = _read_text_sample(file_path, sample_size_bytes, s3_client=s3_client)
+    except UnicodeDecodeError as e:
+        return FormatDetectionResult(
+            format_type=FormatType.MTRL_PARQUET,
+            is_valid=False,
+            lines_sampled=0,
+            errors=[ValidationError(
+                line_number=0,
+                error_type="parse_error",
+                message=f"File has .csv extension but is not valid UTF-8: {e}",
+            )],
+            confidence=ConfidenceLevel.NONE,
+        )
+
+    if not text:
+        return FormatDetectionResult(
+            format_type=FormatType.MTRL_PARQUET,
+            is_valid=False,
+            lines_sampled=0,
+            errors=[ValidationError(
+                line_number=0,
+                error_type="invalid_structure",
+                message="File has .csv extension but is empty",
+            )],
+            confidence=ConfidenceLevel.NONE,
+        )
+
+    try:
+        reader = csv.reader(io.StringIO(text))
+        rows = list(reader)
+    except csv.Error as e:
+        return FormatDetectionResult(
+            format_type=FormatType.MTRL_PARQUET,
+            is_valid=False,
+            lines_sampled=0,
+            errors=[ValidationError(
+                line_number=0,
+                error_type="parse_error",
+                message=f"Failed to parse CSV: {e}",
+            )],
+            confidence=ConfidenceLevel.NONE,
+        )
+
+    if not rows:
+        return FormatDetectionResult(
+            format_type=FormatType.MTRL_PARQUET,
+            is_valid=False,
+            lines_sampled=0,
+            errors=[ValidationError(
+                line_number=0,
+                error_type="invalid_structure",
+                message="CSV file is empty",
+            )],
+            confidence=ConfidenceLevel.NONE,
+        )
+
+    header = rows[0]
+    if not header or all(not col.strip() for col in header):
+        return FormatDetectionResult(
+            format_type=FormatType.MTRL_PARQUET,
+            is_valid=False,
+            lines_sampled=len(rows),
+            errors=[ValidationError(
+                line_number=1,
+                error_type="invalid_structure",
+                message="CSV header row has no columns",
+            )],
+            confidence=ConfidenceLevel.NONE,
+        )
+
+    has_prompt_column = "prompt" in header
+    if has_prompt_column:
+        logger.debug("CSV detection: MTRL-compatible (prompt column) at %s", file_path)
+        return FormatDetectionResult(
+            format_type=FormatType.MTRL_PARQUET,
+            is_valid=True,
+            lines_sampled=len(rows),
+            errors=[],
+            confidence=ConfidenceLevel.HIGH,
+        )
+
+    # No ``prompt`` column: fall back to "first column is the prompt column"
+    # per the SageMaker SDK. The first column's first data value must be a
+    # non-empty string for the file to be MTRL-compatible.
+    if len(rows) < 2:
+        return FormatDetectionResult(
+            format_type=FormatType.MTRL_PARQUET,
+            is_valid=False,
+            lines_sampled=len(rows),
+            errors=[ValidationError(
+                line_number=1,
+                error_type="invalid_structure",
+                message="CSV has no data rows; cannot infer prompt column from first row",
+            )],
+            confidence=ConfidenceLevel.NONE,
+        )
+
+    first_data_row = rows[1]
+    if not first_data_row or not isinstance(first_data_row[0], str) or not first_data_row[0]:
+        return FormatDetectionResult(
+            format_type=FormatType.MTRL_PARQUET,
+            is_valid=False,
+            lines_sampled=len(rows),
+            errors=[ValidationError(
+                line_number=2,
+                error_type="invalid_structure",
+                message="CSV has no 'prompt' column and the first column's first value is not a non-empty string",
+            )],
+            confidence=ConfidenceLevel.NONE,
+        )
+
+    logger.debug("CSV detection: MTRL-compatible (first-column fallback) at %s", file_path)
+    return FormatDetectionResult(
+        format_type=FormatType.MTRL_PARQUET,
+        is_valid=True,
+        lines_sampled=len(rows),
+        errors=[],
+        confidence=ConfidenceLevel.HIGH,
+    )
 
 
 def _classify_nova_format(record: dict) -> FormatType:
@@ -579,6 +1079,22 @@ def detect_format(file_path: str, sample_size_bytes: int = 1_048_576, s3_client=
     Returns:
         FormatDetectionResult with format type, validation status, and any errors
     """
+    # Parquet short-circuit: detect by ``.parquet`` extension and PAR1 magic
+    # bytes before the JSONL line-sampling path runs.
+    if file_path.endswith(".parquet"):
+        return _detect_parquet(file_path, s3_client=s3_client)
+
+    # MTRL-compatible CSV files: a header with at least one column, where
+    # either a ``prompt`` column is present or the first column is
+    # string-typed (per design Property 2 / R3.3).
+    if file_path.endswith(".csv"):
+        return _detect_csv(file_path, sample_size_bytes, s3_client=s3_client)
+
+    # MTRL-compatible JSON-array files: a non-empty top-level array whose
+    # first element has a ``prompt`` column or a single string column.
+    if file_path.endswith(".json"):
+        return _detect_json_array(file_path, sample_size_bytes, s3_client=s3_client)
+
     if file_path.startswith("s3://"):
         lines = _sample_s3_file(file_path, sample_size_bytes, s3_client=s3_client)
     else:
@@ -613,7 +1129,25 @@ def detect_format(file_path: str, sample_size_bytes: int = 1_048_576, s3_client=
     
     # Classify schema using first successfully parsed record
     format_type = _classify_schema(parsed_records)
-    
+
+    # MTRL JSONL relabel: when the existing 11-format classifier returns
+    # UNKNOWN AND the first record is a single-key dict whose key is exactly
+    # ``prompt`` with a string value, relabel as MTRL_PARQUET. The existing
+    # 11 known formats win first (R11.2): if any of them matched, this branch
+    # is never taken, so no JSONL file that classified previously is touched.
+    if format_type == FormatType.UNKNOWN and _is_mtrl_jsonl_record(parsed_records[0]):
+        logger.debug("JSONL detection: relabelling UNKNOWN single-prompt record as MTRL_PARQUET at %s", file_path)
+        return FormatDetectionResult(
+            format_type=FormatType.MTRL_PARQUET,
+            is_valid=True,
+            lines_sampled=len(lines),
+            # Preserve any parse errors (e.g., bad lines later in the sample)
+            # but drop the schema-mismatch noise that would have come from
+            # _validate_samples on UNKNOWN.
+            errors=[err for err in errors if err.error_type == "parse_error"],
+            confidence=ConfidenceLevel.HIGH if not errors else ConfidenceLevel.LOW,
+        )
+
     # Validate all parsed records against detected format
     is_valid, validation_errors = _validate_samples(parsed_records, format_type, line_numbers)
     errors.extend(validation_errors)

--- a/plugins/sagemaker-ai/skills/dataset-transformation/SKILL.md
+++ b/plugins/sagemaker-ai/skills/dataset-transformation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dataset-transformation
-description: Generates a Jupyter notebook that transforms datasets between ML schemas for model training or evaluation. Use when the user says "transform", "convert", "reformat", "change the format", or when a dataset's schema needs to change to match the target format — always use this skill for format changes rather than writing inline transformation code. Supports OpenAI chat, SageMaker SFT/DPO/RLVR, HuggingFace preference, Bedrock Nova, VERL, and custom JSONL formats from local files or S3.
+description: Generates a Jupyter notebook that transforms datasets between ML schemas for model training or evaluation. Use when the user says "transform", "convert", "reformat", "change the format", or when a dataset's schema needs to change to match the target format — always use this skill for format changes rather than writing inline transformation code. Supports OpenAI chat, SageMaker SFT/DPO/RLVR/MTRL, HuggingFace preference, Bedrock Nova, VERL, and custom JSONL/Parquet formats from local files or S3.
 metadata:
   version: "1.0.0"
 ---
@@ -24,7 +24,7 @@ Transforms a data set provided by the user into their desired format. All transf
 5. **No repetition.** If you said something before a tool call, don't repeat it after. Only share new information.
 6. **Do not deviate from the Workflow.** The steps listed in the workflow should be followed exactly as described. Progress from Step 1 to Step 11 to complete the task. Do not deviate from the workflow!
 7. **Always end with a question.** Whenever you pause for user input, acknowledgment, or feedback, your response must end with a question. Never leave the user with a statement and expect them to know they need to respond.
-8. **Default output format is JSONL.** Unless the user explicitly requests a different file format, the transformed dataset should be written as `.jsonl` (JSON Lines — one JSON object per line).
+8. **Default output format is JSONL.** Unless the user explicitly requests a different file format, the transformed dataset should be written as `.jsonl` (JSON Lines — one JSON object per line). **Exception:** when the target format is MTRL, the output is `.parquet` instead — see the MTRL section of `references/dataset_transformation_code.md`.
 
 ## Known Dataset Formats Reference
 
@@ -32,7 +32,9 @@ This skill supports two transformation purposes — **training data** and **eval
 
 ### Training Data Formats
 
-When the transformation is for **model training**, resolve the target format using the reference file `../dataset-evaluation/references/strategy_data_requirements.md`. The required format depends on both the **model type** (Open Weights like Llama/Qwen vs Nova) and the **finetuning technique** (SFT, DPO, RLVR) — make sure to match on both dimensions. If either the model type or technique is not yet known, ask the user before resolving the format.
+When the transformation is for **model training**, resolve the target format using the reference file `../dataset-evaluation/references/strategy_data_requirements.md`. The required format depends on both the **model type** (Open Weights like Llama/Qwen vs Nova) and the **finetuning technique** (SFT, DPO, RLVR, MTRL) — make sure to match on both dimensions. If either the model type or technique is not yet known, ask the user before resolving the format.
+
+For **MTRL** specifically, the target format is a Parquet file with a single string column named `prompt` (see the "MTRL Data Format" section in `strategy_data_requirements.md`). The output extension is `.parquet`, not `.jsonl`. See "MTRL Target Format" in `references/dataset_transformation_code.md` for the function and execution-script skeletons.
 
 ### Evaluation Data Formats
 
@@ -75,7 +77,7 @@ If you know this already, skip this step. If not, ask the user:
 
 Resolve the target format based on the purpose determined in Step 1:
 
-- **If training data**: Ask the user for the finetuning technique (SFT, DPO, RLVR) and model type (Open Weights like Llama/Qwen vs Nova) if not already known. Then look up the required format from the "Training Data Formats" section in the Known Dataset Formats Reference above.
+- **If training data**: Ask the user for the finetuning technique (SFT, DPO, RLVR, MTRL) and model type (Open Weights like Llama/Qwen vs Nova) if not already known. Then look up the required format from the "Training Data Formats" section in the Known Dataset Formats Reference above.
 - **If evaluation data**: If the user mentions a well-known format name (e.g., "OpenAI format", "SageMaker format"), fetch the schema from the live documentation as described in the "Evaluation Data Formats" section above. If a well-known format is fetched, confirm with the user:
 
 > "I've found a SageMaker dataset format: {sagemaker-dataset-format-name} with schema: {sagemaker-dataset-format-schema}. Is this what you were referring to?"
@@ -108,7 +110,7 @@ If you already know where the dataset is supposed to be output to, skip this ste
 
 > "Where should I output your transformed dataset to? Either a local directory or S3 location works!"
 
-If the user provides a directory (not a full file path), construct the output filename using the pattern `{original_name}_{target_format}.jsonl` (e.g., `gen_qa_100k_openai.jsonl`).
+If the user provides a directory (not a full file path), construct the output filename using the pattern `{original_name}_{target_format}.jsonl` (e.g., `gen_qa_100k_openai.jsonl`). **For the MTRL target format**, use `.parquet` as the extension (e.g., `gen_qa_100k_mtrl.parquet`).
 
 ⏸ Wait for user.
 

--- a/plugins/sagemaker-ai/skills/dataset-transformation/references/dataset_transformation_code.md
+++ b/plugins/sagemaker-ai/skills/dataset-transformation/references/dataset_transformation_code.md
@@ -17,6 +17,7 @@ When generating:
 
 - The dataset transformation function should: **ONLY transform the input DataFrame into the target output format. No I/O, no side effects.**
 - The dataset transformation execution script should: **ORCHESTRATE the full pipeline: load the dataset using `load_dataset_from`, apply the transformation function, and write the output using `output_dataset_to`.**
+- For most target formats the output writer uses `df.to_json(local_output, orient="records", lines=True)` (JSONL). For the **MTRL** target format the writer uses `df.to_parquet(local_output, index=False)` and the output filename ends in `.parquet` instead of `.jsonl` (see "MTRL Target Format" below).
 - The script must work in two execution contexts:
   - **Local execution**: paths may be S3 URIs or local file paths
   - **SageMaker Processing Job**: inputs are mounted at `/opt/ml/processing/input/` and outputs go to `/opt/ml/processing/output/`
@@ -133,3 +134,59 @@ print(status)
 ```
 
 Call `describe_transformation_job` repeatedly (every ~30 seconds) until `status` is `Completed`, `Failed`, or `Stopped`.
+
+
+## MTRL Target Format
+
+When the target format is **MTRL** (Multi-Turn Reinforcement Learning), the
+output rules differ from the default JSONL pathway:
+
+- **Output extension**: `.parquet` (not `.jsonl`). Filenames follow the same
+  `{original_name}_{target_format}.{ext}` pattern, with `target_format = "mtrl"`
+  and `ext = "parquet"` (e.g., `gen_qa_100k_mtrl.parquet`).
+- **Output schema**: a single string column named `prompt`. The MTRL service
+  uses the column literally named `prompt`; if no such column exists the
+  first column is used. To make data resilient to that fallback, always emit
+  a column literally named `prompt`.
+- **Structured prompts**: when the source records contain structured task
+  data (e.g., conversation history, tool configs, environment metadata),
+  JSON-encode the entire structure into a single string per record:
+
+  ```python
+  import json
+  data = {"prompt": [json.dumps(task_data) for task_data in records]}
+  ```
+
+  The service forwards the prompt verbatim to the agent environment, which
+  is responsible for parsing it.
+
+### Function skeleton (MTRL)
+
+The transformation function still has the same `transform_dataset(df) -> pd.DataFrame`
+signature; only the *output* schema changes. Example:
+
+```python
+import json
+import pandas as pd
+
+def transform_dataset(df: pd.DataFrame) -> pd.DataFrame:
+    # Build a single-column DataFrame whose values are the JSON-encoded
+    # prompts forwarded to the MTRL agent environment.
+    prompts = [json.dumps(record) for record in df.to_dict(orient="records")]
+    return pd.DataFrame({"prompt": prompts})
+```
+
+### Execution script (MTRL)
+
+Replace the JSONL writer with a Parquet writer. Everything else (loading,
+arg parsing, S3 vs local I/O) is unchanged:
+
+```python
+# 4. Write transformed output locally as Parquet
+local_output = "/tmp/output_dataset.parquet"
+df.to_parquet(local_output, index=False)
+```
+
+The execution script's `--input` / `--output` arguments still accept S3 URIs
+or local paths. For S3 outputs, ensure the destination path also ends in
+`.parquet`.

--- a/plugins/sagemaker-ai/skills/finetuning-setup/SKILL.md
+++ b/plugins/sagemaker-ai/skills/finetuning-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: finetuning-setup
-description: Selects a base model and fine-tuning technique (SFT, DPO, or RLVR) for the user's use case by querying SageMaker Hub. Use when the user asks which model or technique to use, wants to start fine-tuning, or mentions a model name or family (e.g., "Llama", "Mistral") — always activate even for known model names because the exact Hub model ID must be resolved. Queries available models, validates technique compatibility, and confirms selections.
+description: Selects a base model and fine-tuning technique (SFT, DPO, RLVR, or MTRL) for the user's use case by querying SageMaker Hub. Use when the user asks which model or technique to use, wants to start fine-tuning, or mentions a model name or family (e.g., "Llama", "Mistral") — always activate even for known model names because the exact Hub model ID must be resolved. Queries available models, validates technique compatibility, and confirms selections.
 metadata:
   version: "1.0.0"
 ---
@@ -49,12 +49,14 @@ If you already know the model the user wants to use (from conversation context o
 
 ### Step 3: Determine Finetuning Technique
 
-1. Consult `references/finetune_technique_selection_guide.md` and recommend the best-fit technique (SFT, DPO, or RLVR) for the use case. Present the recommendation and reasoning to the user.
-2. Ask the user if they'd like to go with the recommendation or prefer a different technique.
+1. Consult `references/finetune_technique_selection_guide.md` and recommend the best-fit technique (SFT, DPO, RLVR, or MTRL) for the use case. Present the recommendation and reasoning to the user.
+   - Recommend **MTRL** when the use case involves multi-turn agent interaction, tool use, autonomous decision-making across multiple steps, or rewards that depend on the outcome of an agent rollout (not a single response). MTRL also requires an agent environment to exist (Bedrock AgentCore runtime or a Lambda-fronted custom agent) — mention this so the user knows additional setup is needed inside the `finetuning` skill.
+   - Do NOT recommend MTRL for single-turn input/output use cases that have no agent environment.
+2. Ask the user if they'd like to go with the recommendation or prefer a different technique. If the user explicitly asks for MTRL, respect that choice and proceed even if the use case appears non-agentic.
 3. Once the user confirms a technique, retrieve the finetuning techniques available for the selected model by running: `python finetuning-setup/scripts/get_recipes.py <model-name> <hub-name>`
-   - This returns only the techniques the model actually supports, filtered to SFT, DPO, and RLVR. Only these three techniques are supported — ignore any other techniques even if the model's recipes include them.
+   - This returns only the techniques the model actually supports, filtered to SFT, DPO, RLVR, and MTRL. Only these four techniques are supported — ignore any other techniques even if the model's recipes include them.
 4. If the chosen technique is available for the model, proceed to Step 4.
-5. If the chosen technique is not available for the model, explain that the selected model does not support it on SageMaker and offer to go back to Step 2 to pick a different model that supports the chosen technique.
+5. If the chosen technique is not available for the model, explain that the selected model does not support it on SageMaker and offer to go back to Step 2 to pick a different model that supports the chosen technique. (For MTRL specifically: if the user picked MTRL but the model has no MTRL recipe, state that MTRL is not supported for that model and offer to choose a different model.)
 
 ### Step 4: Confirm Selections
 
@@ -63,7 +65,7 @@ Present a summary to the user:
 ```
 Here's what we've selected:
 - Base model: [model name]
-- Fine-tuning technique: [SFT/DPO/RLVR]
+- Fine-tuning technique: [SFT/DPO/RLVR/MTRL]
 ```
 
 ## References

--- a/plugins/sagemaker-ai/skills/finetuning-setup/references/finetune_technique_selection_guide.md
+++ b/plugins/sagemaker-ai/skills/finetuning-setup/references/finetune_technique_selection_guide.md
@@ -1,6 +1,6 @@
 # Finetuning Technique Selection Guide
 
-Not all models support all techniques. Always validate technique availability against the selected model's recipes before recommending. Only SFT, DPO, and RLVR are supported.
+Not all models support all techniques. Always validate technique availability against the selected model's recipes before recommending. Only SFT, DPO, RLVR, and MTRL are supported.
 
 ## Technique Overview
 
@@ -35,3 +35,19 @@ Not all models support all techniques. Always validate technique availability ag
 
 - SFT: Model learns to imitate gold responses directly
 - RLVR: Model learns to maximize rewards (can be gold similarity or verification-based)
+
+### MTRL (Multi-Turn Reinforcement Learning)
+
+**Use when:**
+
+- Task involves multi-turn agent interaction (tool use, reasoning chains, autonomous decision-making across multiple steps)
+- Reward depends on the outcome of an agent rollout, not on a single response
+- An agent environment exists (Bedrock AgentCore runtime or a custom agent reachable through a Lambda forwarder)
+- Building agentic workflows where the model must plan, call tools, observe results, and decide next steps
+
+**Key difference from RLVR:**
+
+- RLVR: model produces one response, a Lambda computes a reward on it.
+- MTRL: model interacts with an environment over many turns; reward is on the whole trajectory.
+
+**Additional setup**: MTRL training requires an agent environment to be configured. The `finetuning` skill walks you through choosing between Bedrock AgentCore and a custom Lambda-fronted agent during notebook generation.

--- a/plugins/sagemaker-ai/skills/finetuning-setup/scripts/get_recipes.py
+++ b/plugins/sagemaker-ai/skills/finetuning-setup/scripts/get_recipes.py
@@ -18,8 +18,8 @@ detail = sm_client.describe_hub_content(
 
 keywords = detail.get("HubContentSearchKeywords", [])
 
-# Only include SFT, DPO, and RLVR techniques
-supported = {"sft", "dpo", "rlvr"}
+# Only include SFT, DPO, RLVR, and MTRL techniques
+supported = {"sft", "dpo", "rlvr", "mtrl"}
 techniques = sorted(
     t.replace("@recipe:finetuning_", "").split("_")[0]
     for t in keywords

--- a/plugins/sagemaker-ai/skills/finetuning/SKILL.md
+++ b/plugins/sagemaker-ai/skills/finetuning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: finetuning
-description: Generates a Jupyter notebook that fine-tunes a base model using SageMaker serverless training jobs. Use when the user says "start training", "fine-tune my model", "I'm ready to train", or when the plan reaches the finetuning step. Supports SFT, DPO, and RLVR trainers, including RLVR Lambda reward function creation.
+description: Generates a Jupyter notebook that fine-tunes a base model using SageMaker serverless training jobs. Use when the user says "start training", "fine-tune my model", "I'm ready to train", or when the plan reaches the finetuning step. Supports SFT, DPO, RLVR, and MTRL trainers, including RLVR Lambda reward function creation and MTRL agent-environment setup.
 metadata:
   version: "1.0.0"
 ---
@@ -13,7 +13,7 @@ Before starting this workflow, verify:
    - If missing: Activate the `use-case-specification` skill first, then resume
    - DON'T EVER offer to create a use case spec without activating the use-case-specification skill.
 
-2. A fine-tuning technique (SFT, DPO, or RLVR) and base model have already been selected
+2. A fine-tuning technique (SFT, DPO, RLVR, or MTRL) and base model have already been selected
    - If missing: Activate the `finetuning-setup` skill to collect what's missing, then resume
    - Don't make recommendations on the spot. You MUST activate the finetuning-setup skill.
 
@@ -67,6 +67,7 @@ Read the example notebook matching the finetuning strategy:
 - SFT → `references/sft_example.md`
 - DPO → `references/dpo_example.md`
 - RLVR → `references/rlvr_example.md`
+- MTRL → `references/mtrl_example.md`
 
 ### 1.3 Copy Notebook Structure
 
@@ -95,6 +96,14 @@ Read the example notebook matching the finetuning strategy:
 
 3. Save notebook
 
+## 1A. Agent Environment Setup (MTRL only)
+
+> **Skip this section** if `technique != "mtrl"`. SFT/DPO/RLVR runs do not need an agent environment.
+
+If `technique == "mtrl"`: read `references/agent_environment_setup.md` and follow the workflow there. Capture the resolved `AGENT_ENV` value (string ARN, runtime ID, or `CustomAgentLambda` object) for use in Cell 3 of `mtrl_example.md`. After the value is captured, replace the three Cell 3 shapes (3a / 3b / 3c) in the notebook with the single shape that matches the user's choice and the resolved `AGENT_ENV`.
+
+The validator referenced by the workflow lives at `scripts/agent_env_validator.py::validate_agent_env(value) -> (bool, str)` — invoke it for any string value the user supplies. The `CustomAgentLambda` object case (Step 3b in `agent_environment_setup.md`) does not need string validation because the SDK constructor produces the value directly.
+
 ## 2. RLVR Reward Function (for RLVR only, skip this section if technique is SFT or DPO)
 
 ### 2.1 Check Reward Function Status
@@ -118,6 +127,8 @@ Read the example notebook matching the finetuning strategy:
 3. Check if the selected base model is a Meta/Llama model (model ID starts with `meta-`)
    - **If Meta/Llama**: Tell the user they must read and agree to the EULA before using this model. Ask them to manually change `ACCEPT_EULA` to `True` in the notebook after reviewing the license. **NEVER set ACCEPT_EULA to True yourself for Meta/Llama models.**
    - **If non-Meta**: Inform the user of the license for their awareness. No code-level action needed — the `ACCEPT_EULA` variable and `accept_eula` parameter should already be omitted from the notebook (see Step 1.3).
+
+**MTRL note:** MTRL participates in this same Meta vs non-Meta EULA flow exactly like SFT/DPO/RLVR. The MTRL example notebook at `references/mtrl_example.md` already keeps `accept_eula=ACCEPT_EULA` commented in Cell 5 for Meta models — no Cell 5 code change is needed; the agent simply follows the rule above.
 
 ## 4. Notebook Execution
 
@@ -145,4 +156,7 @@ If the user wants to finetune a model they had already customized, follow the in
 - `sft_example.md` - Complete notebook template for Supervised Fine-Tuning
 - `dpo_example.md` - Complete notebook template for Direct Preference Optimization
 - `rlvr_example.md` - Complete notebook template for Reinforcement Learning from Verifiable Rewards
+- `mtrl_example.md` - Complete notebook template for Multi-Turn Reinforcement Learning
+- `agent_environment_setup.md` - Agent environment setup workflow for MTRL (Section 1A)
+- `templates/mtrl_lambda_forwarder_template.py` - Lambda forwarder source template for MTRL custom-agent environments
 - `continuous_customization.md` - Instructions on fine-tuning an already fine-tuned model.

--- a/plugins/sagemaker-ai/skills/finetuning/references/agent_environment_setup.md
+++ b/plugins/sagemaker-ai/skills/finetuning/references/agent_environment_setup.md
@@ -1,0 +1,162 @@
+# Agent Environment Setup (MTRL only)
+
+MTRL trains a model by letting it interact with an external agent over many
+turns. Before the trainer can run, the user must point it at an **agent
+environment**: either a Bedrock AgentCore runtime, or a Lambda function that
+forwards rollouts to a customer-hosted agent.
+
+This reference is loaded by `SKILL.md` Section 1A only when the technique is
+MTRL. SFT/DPO/RLVR runs skip this entire flow (Property 14 invariant).
+
+The end goal is a single value, **`AGENT_ENV`**, that gets dropped into Cell 3
+of `mtrl_example.md`. It is one of:
+
+- A Bedrock AgentCore ARN (e.g.
+  `arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/my-runtime`)
+- A bare AgentCore runtime ID (e.g. `myRuntime-aBcDeFgHiJ`)
+- A Lambda function ARN (e.g.
+  `arn:aws:lambda:us-east-1:123456789012:function:my-fn`)
+- A `CustomAgentLambda` Python object (returned by
+  `CustomAgentLambda.create(...)`)
+
+All four shapes are accepted verbatim by `MultiTurnRLTrainer`, so the agent
+does **not** normalize the value — it captures what the user provides and
+inserts it into the notebook.
+
+Validation of the three string shapes is delegated to
+`scripts/agent_env_validator.py::validate_agent_env(value) -> (bool, str)`.
+The `CustomAgentLambda` object case bypasses string validation because the
+SDK constructor produces it directly.
+
+---
+
+## Workflow
+
+### Step 1 — Ask which agent environment to use
+
+Ask the user:
+
+> Which agent environment do you want to use for MTRL training?
+>
+> - **A) Bedrock AgentCore** — AWS managed agent runtime
+> - **B) Custom Lambda agent** — Lambda forwarder bridging to your own
+>   agent platform (EKS, Fargate, an HTTP service, an SQS-backed worker, …)
+
+Branch on the user's answer.
+
+---
+
+### Step 2 — Branch A: Bedrock AgentCore
+
+Ask the user:
+
+> Do you already have a Bedrock AgentCore runtime, or would you like me to help you set one up or discover existing ones in your account?
+>
+> - **1) I already have a runtime ARN or ID** — paste it below
+> - **2) Help me discover existing runtimes** — I'll look up what's in your account
+> - **3) Help me create a new runtime** — I'll show you how to set one up
+
+Branch on the user's answer.
+
+#### 2a) User already has a runtime
+
+1. Ask the user to paste the value.
+2. Validate with `scripts/agent_env_validator.py::validate_agent_env`.
+   - On success (`agentcore_arn` or `runtime_id`) → set `AGENT_ENV = value`
+     and proceed to Step 4.
+   - On failure → quote the user's value back to them, surface the supported
+     formats (the validator's failure message lists them), and re-ask.
+
+#### 2b) Discover existing runtimes
+
+1. Use the AWS MCP tool `aws___call_aws` with service `bedrock-agentcore-control` and action `list-agent-runtimes` to discover existing runtimes in the user's account.
+2. If runtimes exist, present them to the user and ask them to pick one.
+3. If the list is empty, inform the user and offer to help create a new one (fall through to 2c).
+4. Once the user picks a runtime, validate with `scripts/agent_env_validator.py::validate_agent_env`.
+   - On success → set `AGENT_ENV = value` and proceed to Step 4.
+   - On failure → re-ask.
+
+#### 2c) Create a new runtime
+
+1. Show the CLI snippet for creating a new runtime:
+
+   ```bash
+   aws bedrock-agentcore-control create-agent-runtime \
+     --agent-runtime-name my-mtrl-agent \
+     --description "Agent for MTRL training" \
+     --agent-runtime-artifact '{"containerConfiguration": {"containerUri": "<ECR_IMAGE_URI>"}}'
+   ```
+
+2. Pause until the user provides a runtime ARN or ID.
+3. Validate with `scripts/agent_env_validator.py::validate_agent_env`.
+   - On success → set `AGENT_ENV = value` and proceed to Step 4.
+   - On failure → re-ask.
+
+---
+
+### Step 3 — Branch B: Custom Lambda agent
+
+Ask the user:
+
+> Do you already have a Lambda function for your agent forwarder?
+
+#### 3a) Yes — user has a Lambda
+
+1. Ask the user to paste the Lambda ARN.
+2. Run `validate_agent_env(value)` from `scripts/agent_env_validator.py`.
+   - On success (`lambda_arn`) → set `AGENT_ENV = value` and proceed to
+     Step 4.
+   - On failure → quote the user's value back, surface the supported
+     formats, and re-ask.
+
+#### 3b) No — user wants a new Lambda from the template
+
+1. Copy `templates/mtrl_lambda_forwarder_template.py` into the project
+   directory at `<project-dir>/scripts/agent_lambda_forwarder.py`.
+2. Tell the user to customize `_call_agent` (request shape) and
+   `_handle_agent_error` (error mapping) in the file before running.
+3. Add a notebook cell that creates the Lambda from that source via
+   `CustomAgentLambda.create(...)`:
+
+   ```python
+   from sagemaker.train.custom_agent_lambda import CustomAgentLambda
+
+   adapter = CustomAgentLambda.create(
+       source="../scripts/agent_lambda_forwarder.py",
+       function_name="rft-agent-forwarder",
+       timeout=900,
+       memory_size=1024,
+       # role="arn:aws:iam::123456789012:role/LambdaForwarderRole",
+       # environment={"AGENT_ENDPOINT": "https://your-agent-loadbalancer-url"},
+   )
+   AGENT_ENV = adapter
+   print(f"Agent: {adapter}")
+   ```
+
+4. The resulting `CustomAgentLambda` object is captured directly as
+   `AGENT_ENV`. No string validation is needed — the SDK constructor
+   produces a value the trainer accepts verbatim.
+
+---
+
+### Step 4 — Validate the resolved value
+
+If the value is a string, run `validate_agent_env(value)` one final time. On
+invalid input, surface the supported formats from the validator's failure
+message and return to the matching sub-step (2a / 2b / 3a) to collect a new
+value.
+
+If the value is a `CustomAgentLambda` object (Step 3b), skip string
+validation — the SDK constructor's success implies validity.
+
+---
+
+### Step 5 — Store `AGENT_ENV` for the trainer cell
+
+Set `AGENT_ENV` to the resolved value and keep it for use in **Cell 3** of
+`mtrl_example.md`. The agent inserts the value verbatim into one of the
+three Cell 3 shapes (3a AgentCore, 3b existing Lambda, 3c new Lambda from
+template) and removes the other two before writing the notebook.
+
+After this section completes, return to `SKILL.md` Section 1.2 (template
+selection) with `AGENT_ENV` resolved.

--- a/plugins/sagemaker-ai/skills/finetuning/references/continuous_customization.md
+++ b/plugins/sagemaker-ai/skills/finetuning/references/continuous_customization.md
@@ -137,6 +137,9 @@ Choose the trainer class matching the user's technique for this round:
 | SFT       | `from sagemaker.train.sft_trainer import SFTTrainer`   |
 | DPO       | `from sagemaker.train.dpo_trainer import DPOTrainer`   |
 | RLVR      | `from sagemaker.train.rlvr_trainer import RLVRTrainer` |
+| MTRL      | `from sagemaker.train.multi_turn_rl_trainer import MultiTurnRLTrainer` |
+
+For MTRL specifically, continuous customization must repeat `agent_env=AGENT_ENV` in the trainer call exactly as in the initial training cell. The other parameters in the cell follow the same pattern as for SFT/DPO/RLVR continuous customization.
 
 #### Code (SFT example — swap trainer class for DPO/RLVR)
 

--- a/plugins/sagemaker-ai/skills/finetuning/references/mtrl_example.md
+++ b/plugins/sagemaker-ai/skills/finetuning/references/mtrl_example.md
@@ -1,0 +1,203 @@
+# MTRL (Multi-Turn Reinforcement Learning) Notebook Template
+
+This template provides the complete cell structure for an MTRL finetuning notebook. MTRL trains a model by letting it interact with an agent environment (Bedrock AgentCore or a custom agent reachable through a Lambda forwarder) over multiple turns and rewarding it on the resulting episodes.
+
+---
+
+## Cell 1: Install Dependencies
+
+```python
+!pip install --upgrade 'sagemaker>=3.7.1,<4.0' boto3 -q
+```
+
+---
+
+## Cell 2: Setup & Credentials
+
+```python
+import boto3
+from botocore.exceptions import ClientError
+from sagemaker.ai_registry.dataset import DataSet
+from sagemaker.core.resources import ModelPackageGroup
+from sagemaker.core.helper.session_helper import Session, get_execution_role
+from sagemaker.core import Attribution, set_attribution
+
+set_attribution(Attribution.SAGEMAKER_AGENT_PLUGIN)
+
+# Setup
+sm_client = boto3.Session().client("sagemaker")
+sagemaker_session = Session(sagemaker_client=sm_client)
+bucket = sagemaker_session.default_bucket()
+
+# Configuration - USER please fill in these fields with your information:
+
+BASE_MODEL = ""  # e.g., "openai-reasoning-gpt-oss-20b" or "nova-textgeneration-lite-v2"
+TRAINING_DATA_S3 = ""  # S3 path to .parquet (or .jsonl/.json/.csv)
+S3_OUTPUT_PATH = f"s3://{bucket}/finetuning-output/"
+ROLE_ARN = get_execution_role()  # You can change this to a specific role.
+ACCEPT_EULA = False  # Set to True to accept the base model's End-User License Agreement
+MODEL_PACKAGE_GROUP_NAME = ""  # Auto-generated based on use case
+```
+
+---
+
+## Cell 3: Agent Environment
+
+MTRL training requires an agent environment to be configured. Choose one of the
+options below. Only one of cells 3a, 3b, or 3c should remain in the final
+notebook — the agent will pick the right one based on the user's choice during
+the agent-environment setup sub-flow.
+
+### 3a) Bedrock AgentCore (managed agent runtime)
+
+```python
+# Bedrock AgentCore ARN
+AGENT_ENV = "<filled by agent>"  # e.g., "arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/my-runtime"
+
+# Or provide just the runtime ID (will be resolved to the full ARN automatically)
+# AGENT_ENV = "myRuntime-aBcDeFgHiJ"
+```
+
+### 3b) Custom Lambda agent (existing Lambda)
+
+```python
+# Lambda function ARN of an existing agent forwarder
+AGENT_ENV = "arn:aws:lambda:<region>:<account>:function:<name>"
+```
+
+### 3c) Custom Lambda agent (create new from template)
+
+```python
+from sagemaker.train.custom_agent_lambda import CustomAgentLambda
+
+# Create a Lambda forwarder from the template at
+# ../templates/mtrl_lambda_forwarder_template.py — copy it into your project
+# scripts directory and customize _call_agent / _handle_agent_error before
+# running this cell.
+adapter = CustomAgentLambda.create(
+    source="../scripts/agent_lambda_forwarder.py",
+    function_name="rft-agent-forwarder",
+    timeout=900,
+    memory_size=1024,
+    # role="arn:aws:iam::123456789012:role/LambdaForwarderRole",
+    # environment={"AGENT_ENDPOINT": "https://your-agent-loadbalancer-url"},
+)
+AGENT_ENV = adapter
+print(f"Agent: {adapter}")
+```
+
+---
+
+## Cell 4: Create Dataset and Model Package Group(s)
+
+```python
+# Create the output Model Package Group (final trained model lands here).
+try:
+    output_mpg = ModelPackageGroup.create(
+        model_package_group_name=MODEL_PACKAGE_GROUP_NAME,
+        model_package_group_description="",
+    )
+    print(f"Created new model package group named {MODEL_PACKAGE_GROUP_NAME}")
+except ClientError as e:
+    if e.response['Error']['Code'] in ('ResourceInUse', 'ValidationException'):
+        output_mpg = ModelPackageGroup.get(model_package_group_name=MODEL_PACKAGE_GROUP_NAME)
+        print(
+            f"There is already a model package group with the name {MODEL_PACKAGE_GROUP_NAME}.\n"
+            f"If you want to save your finetuned model under a different name, change the value "
+            f"of MODEL_PACKAGE_GROUP_NAME in the previous cell."
+        )
+    else:
+        raise
+
+# Optional: create a separate Model Package Group for intermediate checkpoints.
+# If omitted, MultiTurnRLTrainer auto-creates one named
+# "{model}-mtrl-checkpoint-mpg".
+# checkpoint_mpg = ModelPackageGroup.create(
+#     model_package_group_name=f"{MODEL_PACKAGE_GROUP_NAME}-checkpoints",
+# )
+
+# Register the training dataset in SageMaker AI Registry. This creates a
+# versioned dataset that can be referenced by ARN.
+dataset = DataSet.create(
+    name=MODEL_PACKAGE_GROUP_NAME,
+    source=TRAINING_DATA_S3,
+    wait=True,
+)
+TRAINING_DATASET_ARN = dataset.arn
+
+print(f"Output Model Package Group ARN: {output_mpg.model_package_group_arn}")
+print(f"Training dataset ARN:           {dataset.arn}")
+```
+
+---
+
+## Cell 5: Configure Trainer
+
+```python
+from sagemaker.train.multi_turn_rl_trainer import MultiTurnRLTrainer
+
+trainer = MultiTurnRLTrainer(
+    model=BASE_MODEL,
+    agent_env=AGENT_ENV,
+    training_dataset=TRAINING_DATASET_ARN,
+    s3_output_path=S3_OUTPUT_PATH,
+    sagemaker_session=sagemaker_session,
+    role=ROLE_ARN,
+    output_model_package_group=output_mpg,
+    # accept_eula=ACCEPT_EULA,                                # Uncomment for Meta models
+    # intermediate_checkpoint_model_package_group=checkpoint_mpg,
+    # validation_dataset=VAL_DATASET_ARN,                     # Optional validation prompts
+    # mlflow_resource_arn=MLFLOW_ARN,                         # MLflow App ARN (auto-resolved if absent)
+    # mlflow_experiment_name="my-mtrl-exp",
+    # mlflow_run_name="my-mtrl-run",
+)
+print("Recommended hyperparameters for the current training job:")
+print(trainer.hyperparameters.to_dict())
+```
+
+---
+
+## Cell 6: Hyperparameter Overrides
+
+```python
+# To change a hyperparameter, uncomment its corresponding line and set the value you want.
+# Note: If the value is not supported for your model, the SDK will surface the allowed range.
+
+# Uncomment to change the number of epochs
+# trainer.hyperparameters.max_epochs = 1
+
+# Uncomment to change the global batch size
+# trainer.hyperparameters.global_batch_size = 16
+
+# Uncomment to change the maximum number of steps
+# trainer.hyperparameters.max_steps = 100
+```
+
+---
+
+## Cell 7: Start Training
+
+```python
+# Launch training (set wait=False to return immediately and poll the job manually).
+training_job = trainer.train(wait=True)
+
+print(f"Training Job Name:     {training_job.training_job_name}")
+print(f"Training Status:       {training_job.training_job_status}")
+print(f"Output ModelPackage:   {training_job.output_model_package_arn}")
+# Render a clickable MLflow link in Jupyter (returns the URL string in plain Python).
+training_job.get_mlflow_url()
+```
+
+---
+
+## Cell 8: (Optional) Inspect Job Status
+
+```python
+# Re-attach to the job from a fresh kernel:
+# job = MultiTurnRLTrainer.attach("<training_job_name>")
+# print(job.training_job_status)
+# job.get_mlflow_url()
+#
+# View per-step training metrics from MLflow:
+# job.get_training_metrics()
+```

--- a/plugins/sagemaker-ai/skills/finetuning/scripts/agent_env_validator.py
+++ b/plugins/sagemaker-ai/skills/finetuning/scripts/agent_env_validator.py
@@ -1,0 +1,123 @@
+"""Validate user-supplied AGENT_ENV values for the MTRL finetuning flow.
+
+This module implements the deterministic validator referenced as
+**Property 6** in
+``.kiro/specs/mtrl-finetuning-skill/design.md`` and required by clause
+**R5.7** of the same spec's ``requirements.md``:
+
+    IF the user provides an agent environment value that does not match any
+    supported pattern (AgentCore ARN, runtime ID, Lambda ARN), THEN THE
+    Finetuning Skill SHALL surface an error explaining the supported
+    formats.
+
+The helper recognises three string shapes:
+
+* **AgentCore ARN** — ``arn:aws:bedrock-agentcore:<region>:<account>:runtime/<id>``
+* **Lambda ARN** — ``arn:aws:lambda:<region>:<account>:function:<name>``
+* **Runtime ID** — a bare identifier such as ``my-runtime_01`` (no ``arn:`` prefix)
+
+A ``CustomAgentLambda`` Python object is *not* validated here; it is handled
+by the SKILL prose because it is not a string and reaches the trainer SDK
+unchanged. This module is pure: no I/O, no network or AWS calls, no logging,
+and stdlib-only (``re``).
+"""
+
+from __future__ import annotations
+
+import re
+
+# ---------------------------------------------------------------------------
+# Regex patterns (anchored, compiled once at import time).
+# Kept as module-level constants so tests and other helpers can reuse them.
+# ---------------------------------------------------------------------------
+
+#: Bedrock AgentCore runtime ARN.
+AGENTCORE_ARN_PATTERN: re.Pattern[str] = re.compile(
+    r"^arn:aws:bedrock-agentcore:[^:]+:\d+:runtime/.+$"
+)
+
+#: AWS Lambda function ARN.
+LAMBDA_ARN_PATTERN: re.Pattern[str] = re.compile(
+    r"^arn:aws:lambda:[^:]+:\d+:function:.+$"
+)
+
+#: Runtime ID — alphanumeric start, then alphanumerics, underscores, or
+#: hyphens. Must be at least two characters and must NOT begin with the
+#: literal ``arn:`` prefix (that disambiguates it from malformed ARNs).
+RUNTIME_ID_PATTERN: re.Pattern[str] = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]+$")
+
+
+_SUPPORTED_FORMATS_MESSAGE = (
+    "Invalid AGENT_ENV value. Supported formats are:\n"
+    "  - Bedrock AgentCore ARN: "
+    "arn:aws:bedrock-agentcore:<region>:<account>:runtime/<id>\n"
+    "  - AWS Lambda ARN: "
+    "arn:aws:lambda:<region>:<account>:function:<name>\n"
+    "  - Runtime ID: alphanumeric identifier with optional '-' or '_' "
+    "(no 'arn:' prefix)"
+)
+
+
+def validate_agent_env(value: str) -> tuple[bool, str]:
+    """Validate an AGENT_ENV string against the three supported formats.
+
+    Args:
+        value: The candidate AGENT_ENV string supplied by the user. Must be
+            a ``str``; non-strings (including ``None``) are treated as
+            invalid input.
+
+    Returns:
+        A ``(is_valid, message)`` tuple.
+
+        * On success, ``is_valid`` is ``True`` and ``message`` is one of
+          ``"agentcore_arn"``, ``"lambda_arn"``, or ``"runtime_id"`` —
+          a short label identifying which format matched. Callers that
+          only care about validity can ignore it.
+        * On failure, ``is_valid`` is ``False`` and ``message`` is a
+          human-readable error listing the supported formats (suitable for
+          surfacing to the user verbatim).
+
+    Examples:
+        >>> ok, label = validate_agent_env(
+        ...     "arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/my-rt"
+        ... )
+        >>> ok, label
+        (True, 'agentcore_arn')
+
+        >>> ok, label = validate_agent_env(
+        ...     "arn:aws:lambda:us-east-1:123456789012:function:my-fn"
+        ... )
+        >>> ok, label
+        (True, 'lambda_arn')
+
+        >>> ok, label = validate_agent_env("my-runtime_01")
+        >>> ok, label
+        (True, 'runtime_id')
+
+        >>> ok, _ = validate_agent_env("not a real value")
+        >>> ok
+        False
+
+        >>> ok, _ = validate_agent_env("arn:aws:s3:::my-bucket")
+        >>> ok
+        False
+    """
+    # Defensive type check: this helper is documented as taking ``str``,
+    # but be explicit so test harnesses that pass ``None`` or other types
+    # get a deterministic failure rather than a TypeError from ``re``.
+    if not isinstance(value, str):
+        return False, _SUPPORTED_FORMATS_MESSAGE
+
+    if AGENTCORE_ARN_PATTERN.match(value):
+        return True, "agentcore_arn"
+
+    if LAMBDA_ARN_PATTERN.match(value):
+        return True, "lambda_arn"
+
+    # Runtime ID must NOT start with ``arn:`` — that prefix is reserved for
+    # ARN shapes and a malformed ARN should not silently masquerade as an
+    # identifier.
+    if not value.startswith("arn:") and RUNTIME_ID_PATTERN.match(value):
+        return True, "runtime_id"
+
+    return False, _SUPPORTED_FORMATS_MESSAGE

--- a/plugins/sagemaker-ai/skills/finetuning/templates/mtrl_lambda_forwarder_template.py
+++ b/plugins/sagemaker-ai/skills/finetuning/templates/mtrl_lambda_forwarder_template.py
@@ -1,0 +1,143 @@
+"""Lambda forwarder template for MTRL custom-agent environments.
+
+This module is a starting point for users who want to use a custom agent
+environment (EKS, Fargate, ECS, an HTTP service, an SQS-backed worker, ...)
+as the rollout target for `MultiTurnRLTrainer`. The SageMaker MTRL service
+sends rollout requests to this Lambda; the Lambda forwards them to your
+agent platform and returns the agent's response.
+
+Usage:
+    1. Set the AGENT_ENDPOINT and AGENT_API_KEY environment variables on
+       the Lambda function (prefer AWS Secrets Manager for the API key).
+    2. Customise `_call_agent` so it speaks your platform's request /
+       response shape.
+    3. Customise `_handle_agent_error` if your platform surfaces error
+       codes or response shapes that need translating to the four
+       supported `errorType` values: ``ValidationError``, ``Throttling``,
+       ``InternalServerError``, ``AccessDenied``.
+    4. Deploy via `CustomAgentLambda.create(source="<path-to-this-file>", ...)`
+       or by uploading directly to AWS Lambda and passing the function
+       ARN as `agent_env=` to `MultiTurnRLTrainer`.
+
+If your agent environment does not expose a public HTTP endpoint, replace
+the body of ``_call_agent`` with an SQS ``send_message`` call to enqueue
+the request, and have your agent poll the queue for work.
+
+This template is adapted from Section 5 of
+``v3-examples/model-customization-examples/mtrl_finetuning_example_notebook_v3_prod.ipynb``
+in ``sagemaker-python-sdk-staging`` (master-mtrl-trainer branch).
+"""
+
+import json
+import logging
+import os
+import re
+import urllib.error
+import urllib.request
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+AGENT_ENDPOINT = os.environ.get("AGENT_ENDPOINT", "")
+AGENT_API_KEY = os.environ.get("AGENT_API_KEY", "")
+
+_SAFE_ID = re.compile(r"^[\w\-.]+$")
+
+
+# ---------------------------------------------------------------------------
+# CUSTOMISE THIS — translate the rollout request to your platform's API.
+# ---------------------------------------------------------------------------
+def _call_agent(prompt: str, inference_params: dict) -> dict:
+    """Forward the prompt to your agent platform and return its response.
+
+    Replace the body below with your platform's request format. The
+    SageMaker MTRL service does not require any specific response shape;
+    it only checks for an error envelope (see ``_handle_agent_error``).
+    """
+    payload = json.dumps({
+        "prompt": prompt,
+        "inferenceParams": inference_params,
+    }).encode()
+
+    req = urllib.request.Request(
+        AGENT_ENDPOINT,
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {AGENT_API_KEY}",
+        },
+        method="POST",
+    )
+
+    with urllib.request.urlopen(req, timeout=120) as resp:  # noqa: S310 - HTTPS endpoint expected
+        return json.loads(resp.read())
+
+
+# ---------------------------------------------------------------------------
+# Validation — no changes needed.
+# ---------------------------------------------------------------------------
+def _validate(event: dict) -> dict:
+    body = json.loads(event["body"]) if isinstance(event.get("body"), str) else event
+
+    prompt = body.get("prompt")
+    if not isinstance(prompt, str) or not prompt.strip():
+        raise ValueError("'prompt' is required and must be a non-empty string")
+
+    meta = body.get("metadata")
+    if not isinstance(meta, dict):
+        raise ValueError("'metadata' is required")
+    for key in ("jobId", "experimentId", "rolloutId"):
+        val = meta.get(key)
+        if not isinstance(val, str) or not _SAFE_ID.match(val):
+            raise ValueError(f"metadata.{key} must match [a-zA-Z0-9_\\-.]")
+
+    params = body.get("inferenceParams") or {}
+    if not isinstance(params, dict):
+        raise ValueError("'inferenceParams' must be an object")
+
+    return {
+        "prompt": prompt.strip(),
+        "metadata": {k: meta[k] for k in ("jobId", "experimentId", "rolloutId")},
+        "inferenceParams": params,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CUSTOMISE THIS — handle errors thrown from your agent environment.
+# Supported errorType values: ValidationError, Throttling,
+# InternalServerError, AccessDenied.
+# ---------------------------------------------------------------------------
+def _handle_agent_error(exc: Exception) -> dict:
+    logger.exception("Agent environment error")
+    if isinstance(exc, urllib.error.HTTPError):
+        code = exc.code
+        if code == 403:
+            return {"errorType": "AccessDenied", "error": "Agent denied access"}
+        if code == 429:
+            return {"errorType": "Throttling", "error": "Agent rate limit exceeded"}
+        if 400 <= code < 500:
+            return {"errorType": "ValidationError", "error": str(exc)}
+        return {"errorType": "InternalServerError", "error": str(exc)}
+    return {"errorType": "InternalServerError", "error": str(exc)}
+
+
+def lambda_handler(event, context):
+    """AWS Lambda entrypoint.
+
+    The SageMaker MTRL service invokes this handler for every rollout. On
+    success the handler returns an empty dict (``{}``); on failure it
+    returns one of the four error envelopes described in
+    ``_handle_agent_error``.
+    """
+    try:
+        body = _validate(event)
+    except ValueError as exc:
+        logger.warning("Validation error: %s", exc)
+        return {"errorType": "ValidationError", "error": str(exc)}
+
+    try:
+        _call_agent(body["prompt"], body["inferenceParams"])
+        logger.info("Rollout %s completed", body["metadata"]["rolloutId"])
+        return {}
+    except Exception as exc:  # noqa: BLE001 - intentionally broad; handler reshapes
+        return _handle_agent_error(exc)

--- a/plugins/sagemaker-ai/skills/model-deployment/SKILL.md
+++ b/plugins/sagemaker-ai/skills/model-deployment/SKILL.md
@@ -11,13 +11,13 @@ Identifies the correct deployment pathway based on model characteristics and gen
 
 ## Scope
 
-This skill supports deploying Nova and OSS models that were fine-tuned through **SageMaker Serverless Model Customization** only.
+This skill supports deploying Nova, OSS, and MTRL-trained models that were fine-tuned through **SageMaker Serverless Model Customization** only.
 
 **Not supported:**
 
 - Base models (not fine-tuned)
 - Models fine-tuned through other processes
-- Full Fine-Tuning (FFT) — only LoRA fine-tuned models are supported
+- Full Fine-Tuning (FFT) — only LoRA fine-tuned models are supported. This restriction also applies to MTRL-trained models — only LoRA fine-tuned MTRL models are supported (R8.8).
 
 ## Principles
 
@@ -41,11 +41,13 @@ Once you have the training job name or ARN, use the AWS MCP tool to look it up:
    - **Region**
 2. Use the AWS MCP tool `list-tags` on the training job ARN and extract:
    - **Model ID** from the `sagemaker-studio:jumpstart-model-id` tag
+   - **Recipe / training technique** from the `sagemaker:training_recipe`, `sagemaker-studio:hyperparameters:training_recipe`, or `sagemaker-studio:training-technique` tag (whichever is present)
 3. Determine the **model type** from the model ID:
    - Contains "nova" (nova-micro, nova-lite, nova-pro) → **Nova**
    - Llama, Mistral, Qwen, GPT-OSS, DeepSeek, etc. → **OSS**
+4. Determine whether the model was **MTRL-trained** by checking the recipe / technique tag from step 2. If the tag value contains `mtrl` (case-insensitive), the model is MTRL-trained. The deterministic helper `scripts/eval_type_selector.py::auto_select_eval_type(training_job_tags)` (in the model-evaluation skill) encodes the same rule (it returns `"MTRL Evaluation"` when the tags indicate MTRL); the model-deployment skill reuses the same detection. Record the MTRL flag alongside the model type — both feed Step 5's pathway selection.
 
-**Unsupported models:** This skill only supports OSS and Nova models that were LoRA fine-tuned through SageMaker Serverless Model Customization. If the model doesn't match, tell the user this skill can't help and suggest the finetuning skill.
+**Unsupported models:** This skill only supports OSS, Nova, and MTRL-trained models that were LoRA fine-tuned through SageMaker Serverless Model Customization. If the model doesn't match, tell the user this skill can't help and suggest the finetuning skill.
 
 ### Step 2: Determine Eligible Deployment Targets
 
@@ -55,6 +57,7 @@ Use the following table:
 | ---------- | ------------------ |
 | OSS        | SageMaker, Bedrock |
 | Nova       | SageMaker, Bedrock |
+| MTRL       | SageMaker, Bedrock |
 
 If only one target is eligible, confirm it with the user. Use details from Step 5.
 
@@ -99,12 +102,14 @@ Before proceeding to deployment, display the model's license or service terms to
 
 Read the reference file for the selected pathway and follow its instructions.
 
-| Model Type | Deployment Target | Reference                             |
-| ---------- | ----------------- | ------------------------------------- |
-| OSS        | SageMaker         | `references/deploy-oss-sagemaker.md`  |
-| OSS        | Bedrock           | `references/deploy-oss-bedrock.md`    |
-| Nova       | SageMaker         | `references/deploy-nova-sagemaker.md` |
-| Nova       | Bedrock           | `references/deploy-nova-bedrock.md`   |
+| Model Type | Deployment Target | Reference                              |
+| ---------- | ----------------- | -------------------------------------- |
+| OSS        | SageMaker         | `references/deploy-oss-sagemaker.md`   |
+| OSS        | Bedrock           | `references/deploy-oss-bedrock.md`     |
+| Nova       | SageMaker         | `references/deploy-nova-sagemaker.md`  |
+| Nova       | Bedrock           | `references/deploy-nova-bedrock.md`    |
+| MTRL       | SageMaker         | `references/deploy-mtrl-sagemaker.md`  |
+| MTRL       | Bedrock           | `references/deploy-mtrl-bedrock.md`    |
 
 ### Step 6: Post-Deployment Summary
 

--- a/plugins/sagemaker-ai/skills/model-deployment/references/deploy-mtrl-bedrock.md
+++ b/plugins/sagemaker-ai/skills/model-deployment/references/deploy-mtrl-bedrock.md
@@ -1,0 +1,218 @@
+# Deploy MTRL-trained Model to Bedrock
+
+## Scenario
+
+- **Model Type**: MTRL (Multi-Turn Reinforcement Learning)
+- **Fine-tuning Method**: LoRA
+- **Deployment Target**: Bedrock (Custom Model or Custom Model Import)
+- **Approach**: SageMaker PySdk `BedrockModelBuilder` from
+  `sagemaker.serve.bedrock_model_builder`
+
+## Overview
+
+Uses the SageMaker PySdk `BedrockModelBuilder` to register an
+MTRL-trained model package with Bedrock. The builder takes the
+`ModelPackage` directly (the MTRL trainer registers the output as a
+package in a `ModelPackageGroup`), and the deploy call picks one of two
+kwarg shapes depending on the source JumpStart model family:
+
+- **Nova-family** base models (id starts with `nova-`) → register as a
+  Bedrock **custom model** via `custom_model_name=`.
+- **All other** base models (Llama, Mistral, GPT-OSS, Qwen, etc.) →
+  register as a Bedrock **imported model** via `imported_model_name=`.
+
+Both calls also pass `role_arn=` and `deployment_name=`. The selection is
+deterministic and is computed by
+`scripts/bedrock_deploy_selector.py::select_bedrock_deploy_kwarg(jumpstart_model_id)`.
+
+This pattern matches the `bedrock-s1-deploy` / `bedrock-s2-deploy` cells
+in `mtrl_dogfooding_notebook.ipynb`. Requires `sagemaker>=3.7.0`.
+
+**Required inputs** (collected in the steps below):
+
+- Model package ARN (from the MTRL training job's
+  `output_model_package_arn`)
+- IAM role ARN (with Bedrock trust policy and S3 read access)
+- AWS region
+- Deployment name (suggested by the agent, confirmed by the user)
+- JumpStart model id (used by the agent to pick the right deploy kwarg)
+
+## Prerequisites
+
+### Region
+
+Bedrock Custom Model Import is available in: `us-east-1`, `us-east-2`,
+`us-west-2`, `eu-central-1`. Bedrock custom-model registration for Nova
+follows Bedrock's regional availability for Nova; check with the user.
+
+### SDK Version
+
+Requires `sagemaker>=3.7.1` with `BedrockModelBuilder` support.
+
+## Workflow
+
+### Step 1: Gather Training Job and Model Package ARN
+
+The training job name was identified in Step 1 of the main workflow.
+Confirm you have it. Resolve the **output model package ARN** for the
+MTRL run by reading `output_model_package_arn` from the training job's
+metadata. Confirm `MODEL_PACKAGE_ARN` with the user.
+
+### Step 2: Determine the Bedrock Deploy Kwarg
+
+For this step, you need: **the JumpStart model id of the base model the
+MTRL run started from.** Look it up from the training job's
+`sagemaker-studio:jumpstart-model-id` tag (already gathered in Step 1 of
+the main workflow).
+
+Pick the right deploy kwarg using
+`scripts/bedrock_deploy_selector.py::select_bedrock_deploy_kwarg(jumpstart_model_id)`:
+
+- `jumpstart_model_id` starts with `nova-` → `custom_model_name`
+- otherwise → `imported_model_name`
+
+Both calls also pass `role_arn=` and `deployment_name=`.
+
+The selected kwarg name fills the `[DEPLOY_KWARG_NAME]` placeholder in
+Cell 4 of `../scripts/deploy-mtrl-bedrock.py`. Do not present this
+choice to the user — it is deterministic — but record it in the
+configuration summary so the user can verify.
+
+### Step 3: Suggest Deployment Name
+
+Suggest a deployment name based on the project (lowercase, alphanumeric
+with hyphens). Confirm with the user.
+
+### Step 4: Verify IAM Role
+
+Use the IAM role from the training job (extracted in Step 1 of the main
+workflow via `describe-training-job`). The role must have
+`bedrock.amazonaws.com` in its trust policy and S3 read permissions on
+the model bucket. Confirm with the user.
+
+### Step 5: Confirm Region
+
+The region was identified in Step 1 of the main workflow. Confirm it is
+in the supported list above. If not, tell the user that Bedrock
+deployment is not supported for this model in this region.
+
+### Step 6: Confirm Configuration
+
+> "Here's the deployment setup:
+>
+> - Target: Bedrock
+> - Model Type: MTRL
+> - Model Package ARN: [arn]
+> - Base model id: [jumpstart_model_id]
+> - Deploy kwarg: [custom_model_name | imported_model_name]
+> - IAM Role: [arn]
+> - Region: [region]
+> - Deployment Name: [name]
+>
+> Does this look right?"
+
+⏸ Wait for user approval.
+
+### Step 7: Generate Notebook
+
+If a project directory already exists (from earlier in the workflow), use
+it. Otherwise, activate the **directory-management** skill to set one up.
+
+Check if the project notebook already exists at
+`<project-dir>/notebooks/<project-name>.ipynb`.
+
+- If it exists → ask: _"Would you like me to append the deployment cells
+  to the existing notebook, or create a new one?"_
+- If it doesn't exist → create it.
+
+When appending, add a markdown header cell `## Model Deployment — Bedrock
+(MTRL)` as a section divider before the new cells.
+
+⏸ Wait for user.
+
+## Notebook Structure
+
+### Markdown Header
+
+```json
+{
+  "cell_type": "markdown",
+  "metadata": {},
+  "source": [
+    "# Deploy MTRL Model to Bedrock"
+  ]
+}
+```
+
+### Cells
+
+Each cell's content comes from `../scripts/deploy-mtrl-bedrock.py`,
+split on the `# Cell N:` comments.
+
+- **Cell 1**: Setup (pip install)
+- **Cell 2**: Configuration (REGION, MODEL_PACKAGE_ARN, ROLE_ARN,
+  DEPLOYMENT_NAME)
+- **Cell 3**: Build
+  (`BedrockModelBuilder(model=ModelPackage.get(...))`)
+- **Cell 4**: Deploy (template literal — replace
+  `[DEPLOY_KWARG_NAME]` with `custom_model_name` or
+  `imported_model_name` before writing into the notebook)
+- **Cell 5**: Test Inference (`bedrock-runtime invoke_model`)
+
+### Placeholders
+
+Cell 2:
+
+- `[REGION]` → AWS region (string)
+- `[MODEL_PACKAGE_ARN]` → ARN of the MTRL training output model package
+- `[ROLE_ARN]` → IAM role ARN with Bedrock trust policy
+- `[DEPLOYMENT_NAME]` → Name for the Bedrock deployment
+
+Cell 4:
+
+- `[DEPLOY_KWARG_NAME]` → either `custom_model_name` (Nova-family) or
+  `imported_model_name` (everything else). The agent computes this with
+  `scripts/bedrock_deploy_selector.py::select_bedrock_deploy_kwarg`.
+  Cell 4 in the source file is a **template literal** (wrapped in a
+  triple-quoted string) so the unrendered file parses as valid Python;
+  unwrap and substitute when writing the cell into the notebook.
+
+### Step 8: Provide Run Instructions
+
+```
+To run:
+1. Cell 1 — install/upgrade SageMaker SDK
+2. Cell 2 — configuration and imports (resolves ModelPackage)
+3. Cell 3 — builds the model via BedrockModelBuilder
+4. Cell 4 — deploys to Bedrock (with the substituted deploy kwarg;
+   ~5-10 min)
+5. Cell 5 — test inference with a sample prompt
+```
+
+## Common Issues
+
+- **"No module named 'sagemaker.serve.bedrock_model_builder'"**:
+  Upgrade SDK: `pip install --upgrade 'sagemaker>=3.7.1,<4.0'`.
+- **"Provided IAM role could not be assumed"**: Ensure the role's trust
+  policy allows `bedrock.amazonaws.com`.
+- **"Access denied to S3"**: Add S3 read permissions to the IAM role for
+  the model bucket.
+- **Wrong deploy kwarg**: If Bedrock returns a validation error about
+  `imported_model_name` vs `custom_model_name`, check the JumpStart
+  model id prefix — Nova models must use `custom_model_name`.
+- **Region not supported**: Bedrock CMI is limited to the regions listed
+  in Prerequisites. Choose a different region or pick the SageMaker
+  endpoint pathway.
+
+## Post-Deployment Summary
+
+After the notebook runs successfully, tell the user:
+
+- **Deployment**: `[DEPLOYMENT_NAME]` is now registered with Bedrock.
+- **How to invoke**: Use Bedrock runtime `invoke_model` with the
+  deployment name as `modelId` (see Cell 5 for an example).
+- **Billing**: Pay per request — no cost while idle.
+- **Cleanup**: When done, delete the deployment using the AWS MCP tool
+  `delete-imported-model` (Bedrock service, for `imported_model_name`)
+  or `delete-custom-model` (for `custom_model_name`) with
+  `[DEPLOYMENT_NAME]`.

--- a/plugins/sagemaker-ai/skills/model-deployment/references/deploy-mtrl-sagemaker.md
+++ b/plugins/sagemaker-ai/skills/model-deployment/references/deploy-mtrl-sagemaker.md
@@ -1,0 +1,221 @@
+# Deploy MTRL-trained Model to SageMaker Endpoint
+
+## Scenario
+
+- **Model Type**: MTRL (Multi-Turn Reinforcement Learning)
+- **Fine-tuning Method**: LoRA
+- **Deployment Target**: SageMaker Endpoint
+- **Approach**: SageMaker PySdk `ModelBuilder` from `sagemaker.serve`
+
+## Overview
+
+Uses the SageMaker PySdk `ModelBuilder` to deploy an MTRL-trained model to a
+SageMaker endpoint. The MTRL training output is a `ModelPackage` (already
+registered in a `ModelPackageGroup` by `MultiTurnRLTrainer`), so the builder
+takes the `ModelPackage` directly and resolves the container image and
+artifact location automatically. Requires `sagemaker>=3.7.0`.
+
+This pathway does **not** route through `JumpStartModel` because the
+training output is a packaged model package, not a JumpStart hub artifact.
+That is the same `ModelBuilder(model=ModelPackage.get(...))` pattern used
+in the `s1-deploy` / `s2-deploy` cells of
+`mtrl_dogfooding_notebook.ipynb`.
+
+**Required inputs** (collected in the steps below):
+
+- Model package ARN (from the MTRL training job's
+  `output_model_package_arn`)
+- Instance type (deterministic via `scripts/instance_recommender.py`)
+- IAM execution role ARN
+- AWS region
+- Endpoint name (suggested by the agent, confirmed by the user)
+
+## Prerequisites
+
+### SDK Version
+
+Requires `sagemaker>=3.7.1` with `ModelBuilder.deploy()` support.
+
+## Workflow
+
+### Step 1: Gather Training Job and Model Package ARN
+
+The training job name was identified in Step 1 of the main workflow.
+Confirm you have it.
+
+Resolve the **output model package ARN** for the MTRL run by either:
+
+1. Reading `output_model_package_arn` from the training job's metadata
+   (the `MultiTurnRLTrainer` records it in `plan.md` and as a tag on the
+   training job).
+2. Falling back to `describe-training-job` and inspecting the
+   `OutputDataConfig` / `ModelArtifacts` — for MTRL runs, the output
+   model package is also registered in the `ModelPackageGroup` chosen at
+   training time.
+
+Confirm the resolved `MODEL_PACKAGE_ARN` with the user before proceeding.
+
+### Step 2: Determine Instance Type
+
+For this step, you need: **the SageMaker instance type.**
+
+Recommend an instance based on model size, using the deterministic helper
+`scripts/instance_recommender.py::recommend_instance_type(model_size_b)`.
+The helper encodes the same table the OSS LoRA pathway uses (Property 11
+parity):
+
+| Model size       | Instance type     | GPUs / VRAM      |
+| ---------------- | ----------------- | ---------------- |
+| Small (< 3B)     | `ml.g5.2xlarge`   | 1 GPU, ~24GB     |
+| Medium (< 10B)   | `ml.g5.12xlarge`  | 4 GPUs, ~96GB    |
+| Large (≥ 10B)    | `ml.g6e.48xlarge` | 8 GPUs, ~1TB     |
+
+Pass the recommendation to the user with reasoning and ask them to confirm.
+If they would like a different instance type, accept their choice. If you
+think it will cause issues (for example, not enough GPU memory for the
+model), call that out.
+
+⏸ Wait for user to confirm before moving on.
+
+### Step 3: Verify IAM Role
+
+Use the IAM role from the training job (extracted in Step 1 of the main
+workflow via `describe-training-job`). This role should already have the
+necessary SageMaker and S3 permissions. Confirm with the user.
+
+### Step 4: Confirm Region
+
+The region was identified in Step 1 of the main workflow. Confirm it with
+the user.
+
+### Step 5: Suggest Endpoint Name
+
+Suggest an endpoint name based on the project (lowercase, alphanumeric
+with hyphens). Confirm with the user.
+
+### Step 6: Confirm Configuration
+
+> "Here's the deployment setup:
+>
+> - Target: SageMaker Endpoint
+> - Model Type: MTRL
+> - Model Package ARN: [arn]
+> - Instance Type: [type]
+> - IAM Role: [arn]
+> - Region: [region]
+> - Endpoint Name: [name]
+>
+> Does this look right?"
+
+⏸ Wait for user approval.
+
+### Step 7: Generate Notebook
+
+If a project directory already exists (from earlier in the workflow), use
+it. Otherwise, activate the **directory-management** skill to set one up.
+
+Check if the project notebook already exists at
+`<project-dir>/notebooks/<project-name>.ipynb`.
+
+- If it exists → ask: _"Would you like me to append the deployment cells to
+  the existing notebook, or create a new one?"_
+- If it doesn't exist → create it.
+
+When appending, add a markdown header cell `## Model Deployment — SageMaker
+(MTRL)` as a section divider before the new cells.
+
+⏸ Wait for user.
+
+## Notebook Structure
+
+### Markdown Header
+
+```json
+{
+  "cell_type": "markdown",
+  "metadata": {},
+  "source": [
+    "# Deploy MTRL Model to SageMaker Endpoint"
+  ]
+}
+```
+
+### Cells
+
+Each cell's content comes from `../scripts/deploy-mtrl-sagemaker.py`,
+split on the `# Cell N:` comments.
+
+- **Cell 1**: Setup (pip install)
+- **Cell 2**: Configuration (REGION, INSTANCE_TYPE, MODEL_PACKAGE_ARN,
+  ROLE_ARN, ENDPOINT_NAME, ACCEPT_EULA)
+- **Cell 3**: Build Model (`ModelBuilder(model=ModelPackage.get(...))`)
+- **Cell 4**: Deploy Endpoint
+  (`model_builder.deploy(endpoint_name=..., instance_type=...,
+  initial_instance_count=1)`)
+- **Cell 5**: Test Inference
+  (`sagemaker-runtime invoke_endpoint`)
+
+### Placeholders
+
+Cell 2:
+
+- `[REGION]` → AWS region (string)
+- `[INSTANCE_TYPE]` → SageMaker instance type (e.g., `ml.g5.2xlarge`)
+- `[MODEL_PACKAGE_ARN]` → ARN of the MTRL training output model package
+- `[ROLE_ARN]` → IAM execution role ARN
+- `[ENDPOINT_NAME]` → Name for the endpoint (agent generates a default,
+  user confirms)
+- `[ACCEPT_EULA]` → Python literal `True` if the user accepted the
+  license in Step 4 of the main workflow, `False` otherwise.
+
+### Step 8: Explicitly State EULA Acceptance
+
+Before the user runs the notebook, confirm the EULA acceptance from Step 4
+of the main workflow. Tell the user:
+
+> "Since you accepted the license agreement, I've set EULA acceptance to
+> `True` in the deployment code."
+
+If the user did not accept the license, tell them deployment cannot
+continue without license acceptance.
+
+For Meta/Llama base models, the EULA cannot be auto-accepted — the helper
+returns `(False, "...")` regardless of confirmation state, and the user
+must manually flip `ACCEPT_EULA = True` in the cell after reading the
+license. Surface this to the user verbatim using the helper's message.
+
+### Step 9: Provide Run Instructions
+
+```
+To run:
+1. Cell 1 — install/upgrade SageMaker SDK
+2. Cell 2 — configuration and imports (resolves ModelPackage)
+3. Cell 3 — builds the model via ModelBuilder
+4. Cell 4 — deploys to endpoint (waits for endpoint to be InService,
+   ~5-10 min)
+5. Cell 5 — test inference with a sample prompt
+```
+
+## Common Issues
+
+- **"No module named 'sagemaker.serve'"**: Upgrade SDK:
+  `pip install --upgrade 'sagemaker>=3.7.1,<4.0'`
+- **"Provided IAM role could not be assumed"**: Ensure the role's trust
+  policy allows `sagemaker.amazonaws.com`.
+- **Endpoint creation fails with "Insufficient capacity"**: Try a
+  different instance type or region.
+- **EULA not accepted**: For gated base models, the SDK raises a
+  `ValidationException`. Re-run with `ACCEPT_EULA = True` after reading
+  the license, or use the helper's confirmation flow.
+
+## Post-Deployment Summary
+
+After the notebook runs successfully, tell the user:
+
+- **Endpoint**: `[ENDPOINT_NAME]` is now InService
+- **How to invoke**: Use SageMaker runtime `InvokeEndpoint` with a JSON
+  body matching the model's input schema (see Cell 5 for an example).
+- **Billing**: This endpoint is billed by the hour while running, even
+  when idle. Delete it when you're done testing.
+- **Cleanup**: Delete the endpoint using the AWS MCP tool
+  `delete-endpoint` (SageMaker service) with `[ENDPOINT_NAME]`.

--- a/plugins/sagemaker-ai/skills/model-deployment/scripts/bedrock_deploy_selector.py
+++ b/plugins/sagemaker-ai/skills/model-deployment/scripts/bedrock_deploy_selector.py
@@ -1,0 +1,126 @@
+"""Select the correct Bedrock deploy kwarg name for a JumpStart model id.
+
+This module implements the deterministic helper referenced as
+**Property 10 (Bedrock deployment Nova vs non-Nova selector)** in
+``.kiro/specs/mtrl-finetuning-skill/design.md``. It encodes the rule
+required by:
+
+* **R8.5** — When the user selects Bedrock deployment for an MTRL model,
+  the Model_Deployment Skill SHALL generate cells using
+  ``BedrockModelBuilder`` and call ``bedrock_builder.deploy(...)`` with
+  the appropriate ``custom_model_name`` (Nova) or ``imported_model_name``
+  (non-Nova) parameter.
+
+The helper is consumed by the ``model-deployment`` skill when it
+materialises ``scripts/deploy-mtrl-bedrock.py`` — specifically when it
+fills the ``[DEPLOY_KWARG_NAME]`` placeholder in Cell 4. The selection
+rule is a simple prefix check on the JumpStart model id:
+
+* ``nova-*`` → ``"custom_model_name"`` (Nova-family models register as
+  Bedrock *custom* models because they share the Bedrock Nova model
+  family).
+* every other id → ``"imported_model_name"`` (open-weights / community
+  models register as Bedrock *imported* models).
+
+This module is pure: no I/O, no network or AWS calls, no logging, and
+stdlib-only.
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Prefix that marks a Nova-family JumpStart base model. The id
+#: convention used across this plugin places the family vendor first
+#: (e.g. ``nova-pro``, ``nova-lite``, ``nova-micro``), so a simple
+#: ``startswith`` check is sufficient and matches the design's wording
+#: in Property 10 ("id starts with ``nova-``").
+NOVA_PREFIX: str = "nova-"
+
+#: Kwarg name accepted by ``BedrockModelBuilder.deploy(...)`` for
+#: Nova-family models.
+CUSTOM_MODEL_NAME_KWARG: str = "custom_model_name"
+
+#: Kwarg name accepted by ``BedrockModelBuilder.deploy(...)`` for every
+#: other model id. This is the safer default when the input cannot be
+#: classified (e.g. non-string input), because the Nova path is a
+#: narrower category and mis-routing a non-Nova model to
+#: ``custom_model_name`` would surface a Bedrock validation error,
+#: whereas the imported-model path is the catch-all for all other
+#: open-weights deployments.
+IMPORTED_MODEL_NAME_KWARG: str = "imported_model_name"
+
+
+def select_bedrock_deploy_kwarg(jumpstart_model_id: str) -> str:
+    """Return the Bedrock deploy kwarg name for a JumpStart model id.
+
+    The selection is governed by a single rule (Property 10 in the
+    design document):
+
+    * If ``jumpstart_model_id`` is a string starting with ``nova-``,
+      return ``"custom_model_name"``.
+    * Otherwise, return ``"imported_model_name"``.
+
+    Non-string input (``None``, integers, objects) is treated as
+    non-Nova and routed to ``"imported_model_name"``. This is the
+    safer default because Nova is the narrower category — if the
+    caller hands us a value we cannot classify, we fall back to the
+    catch-all import path rather than silently selecting the
+    custom-model path.
+
+    Args:
+        jumpstart_model_id: The JumpStart base model id (e.g.
+            ``"nova-pro"``, ``"openai-gpt-oss-20b"``,
+            ``"meta-llama-3-8b"``). Must be a ``str``; non-strings are
+            treated defensively as non-Nova.
+
+    Returns:
+        Either ``"custom_model_name"`` or ``"imported_model_name"``.
+        The returned string is the kwarg name the caller must use when
+        invoking ``BedrockModelBuilder.deploy(...)``.
+
+    Examples:
+        Nova-family models route to ``custom_model_name``:
+
+        >>> select_bedrock_deploy_kwarg("nova-pro")
+        'custom_model_name'
+        >>> select_bedrock_deploy_kwarg("nova-lite")
+        'custom_model_name'
+        >>> select_bedrock_deploy_kwarg("nova-micro")
+        'custom_model_name'
+
+        Every other id routes to ``imported_model_name``:
+
+        >>> select_bedrock_deploy_kwarg("openai-gpt-oss-20b")
+        'imported_model_name'
+        >>> select_bedrock_deploy_kwarg("meta-llama-3-8b")
+        'imported_model_name'
+        >>> select_bedrock_deploy_kwarg("mistral-7b")
+        'imported_model_name'
+
+        The match is case-sensitive — only the lowercase ``nova-``
+        prefix triggers the Nova path:
+
+        >>> select_bedrock_deploy_kwarg("Nova-Pro")
+        'imported_model_name'
+
+        Non-string input falls back to the safer default:
+
+        >>> select_bedrock_deploy_kwarg(None)
+        'imported_model_name'
+        >>> select_bedrock_deploy_kwarg("")
+        'imported_model_name'
+    """
+    # Defensive type check: callers are documented to pass strings, but
+    # a non-string ``jumpstart_model_id`` would crash inside
+    # ``startswith``. Treat non-strings as non-Nova and route to the
+    # imported-model path; this is the most conservative behaviour
+    # because Nova is the narrower category.
+    if isinstance(jumpstart_model_id, str) and jumpstart_model_id.startswith(
+        NOVA_PREFIX
+    ):
+        return CUSTOM_MODEL_NAME_KWARG
+
+    return IMPORTED_MODEL_NAME_KWARG

--- a/plugins/sagemaker-ai/skills/model-deployment/scripts/deploy-mtrl-bedrock.py
+++ b/plugins/sagemaker-ai/skills/model-deployment/scripts/deploy-mtrl-bedrock.py
@@ -1,0 +1,72 @@
+# MTRL → Bedrock Custom Model Import deployment cells.
+#
+# This file is **cell-sliced source**. The model-deployment skill reads
+# it, splits on the `# Cell N:` comment markers, and renders each slice
+# into the project notebook. The bracketed tokens
+# (e.g., ``[REGION]``, ``[MODEL_PACKAGE_ARN]``) are placeholders that
+# the agent must replace before writing the notebook. The full
+# placeholder list is documented in
+# ``references/deploy-mtrl-bedrock.md``.
+#
+# Cell 4 is a **template literal** rather than directly executable
+# Python, because ``[DEPLOY_KWARG_NAME]=DEPLOYMENT_NAME`` is not a
+# valid keyword-argument expression. The agent replaces
+# ``[DEPLOY_KWARG_NAME]`` with the literal kwarg name returned by
+# ``scripts/bedrock_deploy_selector.py::select_bedrock_deploy_kwarg``
+# (``custom_model_name`` for Nova-family models, ``imported_model_name``
+# otherwise) when writing the cell into the notebook. Wrapping the
+# template in a triple-quoted string keeps this file syntactically
+# valid Python while preserving the placeholder for substitution.
+
+# Cell 1: Setup
+
+%pip install --upgrade 'sagemaker>=3.7.1,<4.0' boto3 --quiet
+
+# Cell 2: Configuration
+
+import boto3
+import json
+from sagemaker.serve.bedrock_model_builder import BedrockModelBuilder
+from sagemaker.core.resources import ModelPackage
+from sagemaker.core import Attribution, set_attribution
+
+set_attribution(Attribution.SAGEMAKER_AGENT_PLUGIN)
+
+REGION = "[REGION]"
+MODEL_PACKAGE_ARN = "[MODEL_PACKAGE_ARN]"
+ROLE_ARN = "[ROLE_ARN]"
+DEPLOYMENT_NAME = "[DEPLOYMENT_NAME]"
+
+model_package = ModelPackage.get(model_package_arn=MODEL_PACKAGE_ARN)
+print(f"Model package: {model_package.model_package_arn}")
+
+# Cell 3: Build
+
+bedrock_builder = BedrockModelBuilder(model=model_package)
+print(f"BedrockModelBuilder: {bedrock_builder}")
+
+# Cell 4: Deploy
+#
+# Nova models use ``custom_model_name``; non-Nova models use
+# ``imported_model_name``. The agent picks the correct kwarg name based
+# on the JumpStart model id prefix via
+# ``scripts/bedrock_deploy_selector.py::select_bedrock_deploy_kwarg`` and
+# replaces ``[DEPLOY_KWARG_NAME]`` below with the literal kwarg name
+# before writing the cell into the notebook.
+"""
+response = bedrock_builder.deploy(
+    [DEPLOY_KWARG_NAME]=DEPLOYMENT_NAME,
+    role_arn=ROLE_ARN,
+    deployment_name=DEPLOYMENT_NAME,
+)
+print(response)
+"""
+
+# Cell 5: Test Inference
+
+bedrock_runtime = boto3.client("bedrock-runtime", region_name=REGION)
+response = bedrock_runtime.invoke_model(
+    modelId=DEPLOYMENT_NAME,
+    body=json.dumps({"inputText": "Hello"}),
+)
+print(f"Response: {response['body'].read().decode()}")

--- a/plugins/sagemaker-ai/skills/model-deployment/scripts/deploy-mtrl-sagemaker.py
+++ b/plugins/sagemaker-ai/skills/model-deployment/scripts/deploy-mtrl-sagemaker.py
@@ -1,0 +1,71 @@
+# MTRL → SageMaker Multi-Adapter Endpoint deployment cells.
+#
+# This file is **cell-sliced source**. The model-deployment skill reads
+# it, splits on the `# Cell N:` comment markers, and renders each slice
+# into the project notebook. The bracketed tokens
+# (e.g., ``[REGION]``, ``[INSTANCE_TYPE]``) are placeholders that the
+# agent must replace before writing the notebook. The full placeholder
+# list is documented in ``references/deploy-mtrl-sagemaker.md``.
+#
+# This file is intentionally not directly executable — `[ACCEPT_EULA]`
+# is replaced with the literal Python ``True`` / ``False`` based on the
+# user's license acceptance in Step 4 before the cell is written.
+# Running the file directly with placeholders intact is not supported.
+
+# Cell 1: Setup
+
+%pip install --upgrade 'sagemaker>=3.7.1,<4.0' boto3 --quiet
+
+# Cell 2: Configuration
+
+import os
+import json
+import boto3
+
+os.environ["AWS_DEFAULT_REGION"] = "[REGION]"
+
+from sagemaker.serve import ModelBuilder
+from sagemaker.core.resources import ModelPackage
+from sagemaker.core import Attribution, set_attribution
+
+set_attribution(Attribution.SAGEMAKER_AGENT_PLUGIN)
+
+REGION = "[REGION]"
+INSTANCE_TYPE = "[INSTANCE_TYPE]"
+MODEL_PACKAGE_ARN = "[MODEL_PACKAGE_ARN]"
+ROLE_ARN = "[ROLE_ARN]"
+ENDPOINT_NAME = "[ENDPOINT_NAME]"
+ACCEPT_EULA = [ACCEPT_EULA]  # True if user accepted the license in Step 4, False otherwise
+
+model_package = ModelPackage.get(model_package_arn=MODEL_PACKAGE_ARN)
+print(f"Model package: {model_package.model_package_arn}")
+
+# Cell 3: Build Model
+
+model_builder = ModelBuilder(
+    model=model_package,
+    role_arn=ROLE_ARN,
+    instance_type=INSTANCE_TYPE,
+)
+model_builder.accept_eula = ACCEPT_EULA
+model = model_builder.build(model_name=ENDPOINT_NAME)
+print(f"Model: {model}")
+
+# Cell 4: Deploy Endpoint
+
+endpoint = model_builder.deploy(
+    endpoint_name=ENDPOINT_NAME,
+    instance_type=INSTANCE_TYPE,
+    initial_instance_count=1,
+)
+print(f"Endpoint: {endpoint}")
+
+# Cell 5: Test Inference
+
+runtime = boto3.client("sagemaker-runtime", region_name=REGION)
+response = runtime.invoke_endpoint(
+    EndpointName=ENDPOINT_NAME,
+    ContentType="application/json",
+    Body=json.dumps({"inputs": "Hello"}),
+)
+print(f"Response: {response['Body'].read().decode()}")

--- a/plugins/sagemaker-ai/skills/model-deployment/scripts/instance_recommender.py
+++ b/plugins/sagemaker-ai/skills/model-deployment/scripts/instance_recommender.py
@@ -1,0 +1,194 @@
+"""Recommend a SageMaker instance type from a model's parameter count.
+
+This module implements the deterministic helper referenced as
+**Property 11 (SageMaker instance recommendation parity)** in
+``.kiro/specs/mtrl-finetuning-skill/design.md``. It encodes the rule
+required by:
+
+* **R8.4** — When the user selects SageMaker endpoint deployment for an
+  MTRL model, the Model_Deployment Skill SHALL recommend an instance type
+  based on model size, **consistent with the existing OSS instance
+  recommendations**.
+
+The table reused below is the one documented in the OSS LoRA pathway at
+``agent-plugins/plugins/sagemaker-ai/skills/model-deployment/references/deploy-oss-sagemaker.md``
+("Step 2: Determine Instance Type"):
+
+* Small models (<3B):    ``ml.g5.2xlarge``  (1 GPU, ~24GB)
+* Medium models (<10B):  ``ml.g5.12xlarge`` (4 GPUs, ~96GB)
+* Large models (>10B):   ``ml.g6e.48xlarge`` (8 GPUs, ~1TB)
+
+Property 11 is stated as: for any model size bucket
+B ∈ {<3B, <10B, ≥10B}, the recommended SageMaker instance type for an
+MTRL deployment in that bucket equals the recommended instance type for
+an OSS LoRA deployment in the same bucket. To make the buckets cover the
+real line without gaps (the OSS doc reads "<3B / <10B / >10B", which
+leaves an ambiguous point at exactly 10B), this helper treats the upper
+bucket as **≥10B** rather than strict ``>10B``. This is a deliberate
+deviation from the OSS doc wording — the bucket *labels* in Property 11
+already use ``≥10B`` and the boundary value 10.0 must map to the large
+instance to keep the partition complete.
+
+This module is pure: no I/O, no network or AWS calls, no logging, and
+stdlib-only.
+"""
+
+from __future__ import annotations
+
+from numbers import Real
+
+# ---------------------------------------------------------------------------
+# Bucket boundaries (in billions of parameters).
+# ---------------------------------------------------------------------------
+
+#: Upper boundary (exclusive) of the small bucket: any model strictly
+#: smaller than 3B parameters maps to :data:`SMALL_INSTANCE`.
+SMALL_BUCKET_MAX_B: float = 3.0
+
+#: Upper boundary (exclusive) of the medium bucket: any model in
+#: ``[3B, 10B)`` maps to :data:`MEDIUM_INSTANCE`. Model sizes at or
+#: above this value map to :data:`LARGE_INSTANCE`.
+MEDIUM_BUCKET_MAX_B: float = 10.0
+
+# ---------------------------------------------------------------------------
+# Recommended instance types (verbatim from the OSS LoRA reference doc).
+# ---------------------------------------------------------------------------
+
+#: SageMaker instance for ``<3B`` models — 1 GPU, ~24GB.
+SMALL_INSTANCE: str = "ml.g5.2xlarge"
+
+#: SageMaker instance for ``[3B, 10B)`` models — 4 GPUs, ~96GB.
+MEDIUM_INSTANCE: str = "ml.g5.12xlarge"
+
+#: SageMaker instance for ``≥10B`` models — 8 GPUs, ~1TB.
+LARGE_INSTANCE: str = "ml.g6e.48xlarge"
+
+
+def recommend_instance_type(model_size_b: float) -> str:
+    """Return the recommended SageMaker instance type for a model size.
+
+    The recommendation follows the OSS LoRA table reused by the MTRL
+    deployment pathway (Property 11 in the design document):
+
+    * ``model_size_b < 3``   → :data:`SMALL_INSTANCE`  (``ml.g5.2xlarge``)
+    * ``3 ≤ model_size_b < 10`` → :data:`MEDIUM_INSTANCE` (``ml.g5.12xlarge``)
+    * ``model_size_b ≥ 10``  → :data:`LARGE_INSTANCE`  (``ml.g6e.48xlarge``)
+
+    ``model_size_b`` is the model size **in billions of parameters**, so
+    a 7B model is passed as ``7.0`` and a 70B model as ``70.0``. Booleans
+    are explicitly rejected even though Python's numeric tower would
+    otherwise let them through, because passing ``True`` or ``False``
+    here is almost always a type error at the call site.
+
+    Args:
+        model_size_b: Model size in billions of parameters. Must be a
+            non-negative real number (``int`` or ``float``).
+
+    Returns:
+        One of :data:`SMALL_INSTANCE`, :data:`MEDIUM_INSTANCE`, or
+        :data:`LARGE_INSTANCE`.
+
+    Raises:
+        ValueError: If ``model_size_b`` is ``None``, not a real number,
+            a boolean, ``NaN``, or strictly negative. The message lists
+            the supported input shape so the caller can surface it
+            verbatim.
+
+    Examples:
+        Small bucket — strictly below 3B:
+
+        >>> recommend_instance_type(0.5)
+        'ml.g5.2xlarge'
+        >>> recommend_instance_type(2.999)
+        'ml.g5.2xlarge'
+
+        Medium bucket — 3B (inclusive) up to 10B (exclusive):
+
+        >>> recommend_instance_type(3.0)
+        'ml.g5.12xlarge'
+        >>> recommend_instance_type(7.0)
+        'ml.g5.12xlarge'
+        >>> recommend_instance_type(9.999)
+        'ml.g5.12xlarge'
+
+        Large bucket — 10B and above:
+
+        >>> recommend_instance_type(10.0)
+        'ml.g6e.48xlarge'
+        >>> recommend_instance_type(70.0)
+        'ml.g6e.48xlarge'
+
+        Integer inputs are accepted (a 7B model can be passed as ``7``):
+
+        >>> recommend_instance_type(7)
+        'ml.g5.12xlarge'
+
+        Zero is treated as a very small model:
+
+        >>> recommend_instance_type(0)
+        'ml.g5.2xlarge'
+
+        Invalid inputs raise ``ValueError``:
+
+        >>> recommend_instance_type(-1.0)
+        Traceback (most recent call last):
+            ...
+        ValueError: model_size_b must be a non-negative real number (got -1.0)
+        >>> recommend_instance_type(None)
+        Traceback (most recent call last):
+            ...
+        ValueError: model_size_b must be a non-negative real number (got None)
+        >>> recommend_instance_type("7B")
+        Traceback (most recent call last):
+            ...
+        ValueError: model_size_b must be a non-negative real number (got '7B')
+        >>> recommend_instance_type(True)
+        Traceback (most recent call last):
+            ...
+        ValueError: model_size_b must be a non-negative real number (got True)
+    """
+    # Reject booleans up front. ``bool`` is a subclass of ``int``, so a
+    # naive ``isinstance(..., Real)`` check would let ``True``/``False``
+    # through and silently route them to the small-bucket branch.
+    # Passing a boolean here is almost always a type error at the call
+    # site, so fail fast with a clear message.
+    if isinstance(model_size_b, bool):
+        raise ValueError(
+            f"model_size_b must be a non-negative real number "
+            f"(got {model_size_b!r})"
+        )
+
+    # Reject anything that isn't a real number (covers ``None``, strings,
+    # complex numbers, arbitrary objects). ``numbers.Real`` matches
+    # ``int`` and ``float`` (and ``Fraction``, ``Decimal`` is *not*
+    # ``Real`` — that's fine, callers in this plugin only pass int/float).
+    if not isinstance(model_size_b, Real):
+        raise ValueError(
+            f"model_size_b must be a non-negative real number "
+            f"(got {model_size_b!r})"
+        )
+
+    # Reject NaN explicitly: ``float('nan') < 3.0`` is ``False``, so a
+    # NaN input would fall through to the large bucket and silently
+    # recommend the most expensive instance. Surface the bug instead.
+    # ``x != x`` is the canonical NaN check that works without importing
+    # ``math`` and remains correct for non-float ``Real`` subclasses.
+    if model_size_b != model_size_b:
+        raise ValueError(
+            f"model_size_b must be a non-negative real number "
+            f"(got {model_size_b!r})"
+        )
+
+    if model_size_b < 0:
+        raise ValueError(
+            f"model_size_b must be a non-negative real number "
+            f"(got {model_size_b!r})"
+        )
+
+    if model_size_b < SMALL_BUCKET_MAX_B:
+        return SMALL_INSTANCE
+
+    if model_size_b < MEDIUM_BUCKET_MAX_B:
+        return MEDIUM_INSTANCE
+
+    return LARGE_INSTANCE

--- a/plugins/sagemaker-ai/skills/model-evaluation/SKILL.md
+++ b/plugins/sagemaker-ai/skills/model-evaluation/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: model-evaluation
-description: Generates python code that evaluates SageMaker models. Supports two evaluation types: LLM-as-Judge and Custom Scorer. Use when the user says "evaluate my model", "test model performance", "how did my model perform", "compare models", or other similar requests.
+description: Generates python code that evaluates SageMaker models. Supports three evaluation types: LLM-as-Judge, Custom Scorer, and MTRL Evaluation. Use when the user says "evaluate my model", "test model performance", "how did my model perform", "compare models", or other similar requests.
 metadata:
-  version: "2.0.0"
+  version: "2.1.0"
 ---
 
 # Model Evaluation
@@ -28,10 +28,11 @@ If the user requests help evaluating a different type of model, explain to them 
 
 ## Evaluation Types
 
-There are two evaluation types that can be used to evaluate a model:
+There are three evaluation types that can be used to evaluate a model:
 
 - **LLM-as-Judge** — an LLM grades your model's responses.
 - **Custom Scorer** — programmatic evaluation via Lambda function (includes built-in math and code scorers).
+- **MTRL Evaluation** — multi-turn agent rollout against an agent environment, using `MultiTurnRLEvaluator`. Available for MTRL-trained models, and for base JumpStart models that support MTRL when an explicit `agent_config` is provided.
 
 ## Workflow
 
@@ -41,7 +42,13 @@ There are two evaluation types that can be used to evaluate a model:
 
 Check conversation history, plan.md, workflow_state.json, or anything else you've already read.
 
-**If yes:** confirm with the user.
+**Auto-select rule (MTRL).** If you have access to the source training job's tags (from earlier steps in the conversation, plan.md, or via `list-tags` on the training job ARN), call the deterministic helper `scripts/eval_type_selector.py::auto_select_eval_type(training_job_tags)`. If it returns `"MTRL Evaluation"`, default to MTRL Evaluation and confirm with the user before moving to Step 2:
+
+> "It looks like this model was trained with MTRL, so MTRL Evaluation (multi-turn agent rollout) is the natural fit. Want to go with that?"
+
+⏸ Wait for confirmation. If confirmed → go to Step 2. If the user declines, fall through to the manual selection below.
+
+**If you already know from prior context (non-MTRL):** confirm with the user.
 
 > "It sounds like you want to run [evaluation type]. Is that right?"
 
@@ -53,6 +60,7 @@ Check conversation history, plan.md, workflow_state.json, or anything else you'v
 >
 > 1. **LLM-as-Judge** — an LLM grades your model's responses
 > 2. **Custom Scorer** — programmatic scoring (math, code, or your own logic)
+> 3. **MTRL Evaluation** — multi-turn agent rollout against an agent environment (for MTRL-trained models, or base JumpStart models that support MTRL with an explicit `agent_config`)
 >
 > Pick one, or say 'help me decide' if you're not sure."
 
@@ -78,6 +86,16 @@ Before reading the reference file, validate that the chosen evaluation type is c
 
 1. **Does the user have an evaluation dataset?** Custom Scorer requires one. (No model type restriction — works with Nova.)
 
+#### MTRL Evaluation validation
+
+1. **Does the user have an evaluation dataset (Parquet preferred, with a `prompt` column)?** Required (R7.7) — MTRL evaluation runs prompts through the agent environment, so without a dataset there is nothing to evaluate. If the user has no dataset, inform them and stop:
+
+   > "MTRL evaluation requires a dataset of prompts. I can't generate the evaluation cells without one."
+
+2. **Was the model trained with MTRL, or is the user evaluating a base JumpStart model that supports MTRL?**
+   - **Trained with MTRL** → use the trainer-resolved path. The evaluator will re-attach to the training job (`MultiTurnRLTrainer.attach(job_name=...)`) and pass `model=trainer`. No `agent_config` is needed — the evaluator auto-resolves both the output model package and the agent environment from the trainer.
+   - **Base JumpStart model** → require an `agent_config` (AgentCore ARN or Lambda ARN). If the user does not already have one, delegate to the finetuning skill's agent-environment-setup sub-flow at `agent-plugins/plugins/sagemaker-ai/skills/finetuning/references/agent_environment_setup.md`. Capture the resulting `AGENT_ENV` value and use it as `agent_config`.
+
 ---
 
 If validation fails, tell the user which requirement(s) aren't met and offer alternatives:
@@ -96,9 +114,10 @@ If they say they do want help choosing a different eval type → read `reference
 
 If validation passes, read the corresponding reference file:
 
-| User chose    | Read                                     |
-| ------------- | ---------------------------------------- |
-| LLM-as-Judge  | `references/llmaaj-evaluation.md`        |
-| Custom Scorer | `references/custom-scorer-evaluation.md` |
+| User chose       | Read                                     |
+| ---------------- | ---------------------------------------- |
+| LLM-as-Judge     | `references/llmaaj-evaluation.md`        |
+| Custom Scorer    | `references/custom-scorer-evaluation.md` |
+| MTRL Evaluation  | `references/mtrl-evaluation.md`          |
 
 Follow the reference file's instructions from the beginning.

--- a/plugins/sagemaker-ai/skills/model-evaluation/references/evaluation-type-guide.md
+++ b/plugins/sagemaker-ai/skills/model-evaluation/references/evaluation-type-guide.md
@@ -4,19 +4,34 @@ Help the user decide which evaluation type to use based on their goals and const
 
 ## Evaluation types at a glance
 
-| Type          | What it does                                                                                                         | Eval dataset? | Cost   | Supported models |
-| ------------- | -------------------------------------------------------------------------------------------------------------------- | ------------- | ------ | ---------------- |
-| LLM-as-Judge  | An LLM scores your model's responses on subjective qualities like helpfulness, correctness, coherence, and safety.   | Yes           | Higher | OSS only         |
-| Custom Scorer | Your own scoring logic (or a built-in scorer) evaluates outputs programmatically — exact/near match, pattern checks. | Yes           | Lower  | All              |
+| Type            | What it does                                                                                                         | Eval dataset?  | Cost   | Supported models                  |
+| --------------- | -------------------------------------------------------------------------------------------------------------------- | -------------- | ------ | --------------------------------- |
+| LLM-as-Judge    | An LLM scores your model's responses on subjective qualities like helpfulness, correctness, coherence, and safety.   | Yes            | Higher | OSS only                          |
+| Custom Scorer   | Your own scoring logic (or a built-in scorer) evaluates outputs programmatically — exact/near match, pattern checks. | Yes            | Lower  | All                               |
+| MTRL Evaluation | An LLM agent runs an end-to-end multi-turn rollout against an agent environment. Score = success of the rollout.    | Yes (prompts)  | Higher | Models that support MTRL          |
 
 **When to use which — in short:**
 
+- The model was trained with MTRL → **MTRL Evaluation** (auto-recommended).
 - To assess subjective qualities like tone, helpfulness, coherence, or faithfulness → **LLM-as-Judge**
 - When a programmatic approach can give a meaningful signal about output quality → **Custom Scorer**
+- The task is multi-turn / agentic and you want to measure end-to-end rollout success → **MTRL Evaluation**
 
 ## Decision flow
 
 Work through the steps below in order. For each, use what you already know from conversation history, plan.md, workflow_state.json, or other files you've read. Only ask the user if you genuinely don't know.
+
+### Step 0: Was the model trained with MTRL?
+
+Before walking through the rest of the decision flow, check whether the model under evaluation was trained with MTRL. If you have access to the source training job (name, ARN, or its tags from prior conversation), call the deterministic helper `scripts/eval_type_selector.py::auto_select_eval_type(training_job_tags)`.
+
+If it returns `"MTRL Evaluation"` — i.e., the recipe / technique tag indicates MTRL — recommend MTRL Evaluation directly:
+
+> "This model was trained with MTRL, so MTRL Evaluation (multi-turn agent rollout) is the natural fit. Want to go with that?"
+
+⏸ Wait for the user. If confirmed, return to the main SKILL.md workflow (Step 2: Validate and hand off) with MTRL Evaluation. If the user declines, continue with Step 1 below to choose between the other evaluation types.
+
+If you do not have training-job tags, or the helper returns `None`, continue to Step 1.
 
 ### Step 1: Check for evaluation dataset
 

--- a/plugins/sagemaker-ai/skills/model-evaluation/references/mtrl-evaluation.md
+++ b/plugins/sagemaker-ai/skills/model-evaluation/references/mtrl-evaluation.md
@@ -1,0 +1,321 @@
+# MTRL Evaluation
+
+Guide the user through the process for evaluating a model with MTRL Evaluation
+(`MultiTurnRLEvaluator`).
+
+MTRL Evaluation runs an end-to-end **multi-turn rollout** of the model
+against an agent environment. The score is the success of the rollout — the
+agent environment owns reward and trajectory bookkeeping. There are two
+shapes:
+
+- **Trainer-resolved** (the model under evaluation was just trained with
+  MTRL). The evaluator reuses the trainer's `agent_env` and auto-resolves
+  the output model package. No `agent_config` is needed.
+- **Base JumpStart model with explicit `agent_config`** (the user wants to
+  measure a base model that supports MTRL without prior training, per
+  Scenario 3 of `mtrl_dogfooding_notebook.ipynb`). The user must provide
+  an agent environment value (AgentCore ARN or Lambda ARN).
+
+## Workflow
+
+### Step 0: Consider prior context
+
+Before proceeding, silently think about the context you have about the user's
+project, including conversation history and file reads. You should use that
+knowledge, and avoid asking questions you already know the answer to.
+
+In particular, check whether you already know:
+
+- Whether the model under evaluation was trained with MTRL (training-job
+  tags, plan.md, or the user's earlier statements).
+- The training job name or ARN (so a trainer can be re-attached).
+- The agent environment value, if one was already configured during the
+  finetuning skill's Section 1A.
+
+### Step 1: Determine evaluation mode
+
+For this step, you need: **whether to use the trainer-resolved path or the
+base-model path.**
+
+If you already know from context (e.g., the user finished an MTRL training
+run earlier in the conversation, or `plan.md` records an MTRL trainer), use
+the trainer-resolved path and confirm with the user.
+
+Otherwise, ask:
+
+> "Are you evaluating a model you trained with MTRL, or a base JumpStart
+> model that supports MTRL?
+>
+> 1. **Trained with MTRL** — I'll re-attach to the training job and the
+>    evaluator will reuse the trainer's agent environment automatically.
+> 2. **Base JumpStart model** — I'll need a JumpStart model ID and an
+>    agent environment value (AgentCore ARN or Lambda ARN)."
+
+⏸ Wait for user.
+
+### Step 2: Resolve the dataset
+
+For this step, you need: **the evaluation dataset path** (Parquet preferred,
+or any other supported format with a `prompt` column).
+
+If you already know the dataset path from context, confirm it with the user
+and move on.
+
+Otherwise, ask:
+
+> "Where's your evaluation dataset stored? Parquet is preferred, but JSONL,
+> JSON, or CSV with a `prompt` column also work."
+
+⏸ Wait for user.
+
+**MTRL evaluation requires a dataset of prompts.** If the user does not have
+one, inform them and stop (R7.7):
+
+> "MTRL evaluation requires a dataset of prompts. I can't generate the
+> evaluation cells without one."
+
+If the dataset was already validated via the **dataset-evaluation** skill —
+either earlier in this conversation, or in a previous session (recorded in
+`plan.md`) — skip the next step.
+
+Otherwise, activate the **dataset-evaluation** skill to validate the dataset.
+If validation fails, offer to activate the **dataset-transformation** skill
+to convert it to MTRL-compatible Parquet. Do not proceed until the dataset
+is valid.
+
+### Step 3: Resolve the model
+
+#### Step 3a (trainer-resolved): Re-attach to the training job
+
+For this step, you need: **the MTRL training job name.**
+
+If you already know it from context, confirm with the user. Otherwise, ask:
+
+> "What's the name of the MTRL training job I should re-attach to?"
+
+The notebook re-attaches via:
+
+```python
+trainer = MultiTurnRLTrainer.attach(job_name="<training_job_name>")
+```
+
+The evaluator will be constructed with `model=trainer`. No `agent_config` is
+needed — the evaluator auto-resolves both the output model package and the
+agent environment from the trainer.
+
+Skip Step 3b. Continue to Step 4.
+
+#### Step 3b (base-model): Resolve model ID and agent environment
+
+For this step, you need: **the JumpStart model ID** and an
+**`agent_config`** value (AgentCore ARN or Lambda ARN).
+
+If you already know the model ID from context (e.g., the user mentioned
+which base model they wanted to evaluate), confirm. Otherwise, ask:
+
+> "What's the JumpStart model ID of the base model you'd like to evaluate?"
+
+If you already know an agent environment value from a prior agent-env setup
+(e.g., the finetuning skill's Section 1A captured one earlier in the
+conversation), confirm with the user.
+
+Otherwise, the user needs to set up an agent environment first. Delegate to
+the finetuning skill's agent-environment-setup sub-flow:
+
+> "Evaluating a base MTRL model needs an agent environment. Let me walk
+> you through setting one up."
+
+Read
+`agent-plugins/plugins/sagemaker-ai/skills/finetuning/references/agent_environment_setup.md`
+and follow its instructions to capture an `AGENT_ENV` value. Then return
+here. The captured value becomes the evaluator's `agent_config`.
+
+Continue to Step 4.
+
+### Step 4: Resolve standard evaluation inputs
+
+For this step, you need: **IAM role ARN, AWS region, S3 output path, and
+(optionally) MLflow resource ARN.**
+
+For each, use what you already know from context (e.g., the training job's
+role / region / output bucket) and confirm with the user. Only ask for
+inputs you do not already have.
+
+- **IAM role**: prefer the role attached to the source training job
+  (look it up via `describe-training-job` if you have the job name).
+- **Region**: prefer the training job's region.
+- **S3 output**: a path under the user's project bucket like
+  `s3://<bucket>/mtrl-eval/`.
+- **MLflow resource ARN** (optional): if `plan.md` records an MLflow
+  experiment, reuse it.
+
+### Step 5: Confirm configuration and write the cells
+
+Summarize everything and ask for approval:
+
+> "Here's the MTRL evaluation setup:
+>
+> - Mode: [trainer-resolved / base-JumpStart-model]
+> - [If trainer] Training job: [name]
+> - [If base] Base model ID: [id]
+> - [If base] Agent config: [AGENT_ENV]
+> - Dataset: [path]
+> - IAM role: [ARN]
+> - Region: [region]
+> - S3 output: [path]
+> - MLflow ARN: [ARN or 'None']
+>
+> Does this look right?"
+
+⏸ Wait for user approval.
+
+If a project directory already exists (from earlier in the workflow), use
+it. Otherwise, activate the **directory-management** skill to set one up.
+
+Check if the project notebook already exists at
+`<project-dir>/notebooks/<project-name>.ipynb`.
+
+- If it exists → ask: _"Would you like me to append the evaluation cells to
+  the existing notebook, or create a new one?"_
+- If it doesn't exist → create it.
+
+When appending, add a markdown header cell `## Model Evaluation — MTRL` as a
+section divider before the new cells.
+
+⏸ Wait for user.
+
+## Notebook Cells
+
+Render the cells below into the project notebook, picking **either** Cell 3a
+(trainer-resolved, Step 3a) **or** Cell 3b (base-model, Step 3b). The other
+cells are identical for both modes.
+
+### Cell 1: Install dependencies
+
+```python
+!pip install --upgrade 'sagemaker>=3.7.1,<4.0' boto3 -q
+```
+
+### Cell 2: Setup and credentials
+
+```python
+import boto3
+from sagemaker.train.evaluate import MultiTurnRLEvaluator
+from sagemaker.train.multi_turn_rl_trainer import MultiTurnRLTrainer
+from sagemaker.core.helper.session_helper import Session, get_execution_role
+from sagemaker.core import Attribution, set_attribution
+
+set_attribution(Attribution.SAGEMAKER_AGENT_PLUGIN)
+
+REGION = boto3.Session().region_name
+ROLE = get_execution_role()
+S3_OUTPUT = "s3://<bucket>/mtrl-eval/"
+DATASET = "<S3 URI or DataSet ARN of eval prompts>"
+MLFLOW_ARN = ""  # Optional MlflowApp ARN; leave empty to skip
+```
+
+### Cell 3a: Trainer-resolved evaluator (Step 3a only)
+
+```python
+# Re-attach to the MTRL training job. The evaluator will reuse the trainer's
+# agent environment and auto-resolve the output model package.
+trainer = MultiTurnRLTrainer.attach(job_name="<training_job_name>")
+
+evaluator = MultiTurnRLEvaluator(
+    model=trainer,
+    dataset=DATASET,
+    s3_output_path=S3_OUTPUT,
+    mlflow_resource_arn=MLFLOW_ARN or None,
+)
+```
+
+### Cell 3b: Base JumpStart model with explicit `agent_config` (Step 3b only)
+
+```python
+# Evaluate a base JumpStart model that supports MTRL. The agent_config is
+# the AGENT_ENV captured in the agent-environment-setup sub-flow — either
+# an AgentCore ARN or a Lambda ARN.
+AGENT_ENV = "<AgentCore ARN or Lambda ARN>"
+
+evaluator = MultiTurnRLEvaluator(
+    model="<jumpstart-model-id>",
+    dataset=DATASET,
+    agent_config=AGENT_ENV,
+    s3_output_path=S3_OUTPUT,
+    mlflow_resource_arn=MLFLOW_ARN or None,
+)
+```
+
+### Cell 4: Launch evaluation
+
+```python
+exec = evaluator.evaluate()
+print(f"Evaluation execution: {exec}")
+```
+
+### Cell 5: Wait for completion and print status
+
+```python
+exec.wait()
+print(f"Evaluation status: {exec.status.overall_status}")
+```
+
+## Listing prior runs
+
+To list past MTRL evaluation runs in your account, use:
+
+```python
+from sagemaker.train.evaluate import MultiTurnRLEvaluator
+
+for run in MultiTurnRLEvaluator.get_all(region=REGION):
+    print(run)
+```
+
+This is useful for re-attaching to a long-running evaluation from a fresh
+kernel, or for surfacing prior results when comparing models.
+
+## Run instructions
+
+```
+To run:
+1. Cell 1 — install/upgrade SageMaker SDK
+2. Cell 2 — configuration and imports
+3. Cell 3 — construct the evaluator (3a if trainer-resolved, 3b if base-model)
+4. Cell 4 — launch evaluation
+5. Cell 5 — wait for completion (~10-60 min depending on dataset size and
+   agent-environment latency) and print the overall status
+```
+
+## FAQ
+
+**Q: Do I need an `agent_config` for the trainer-resolved path?**
+A: No. The evaluator reads the agent environment off the trainer object and
+reuses it. You only need to provide `agent_config` when evaluating a base
+JumpStart model directly (Step 3b).
+
+**Q: What dataset format does MTRL evaluation accept?**
+A: Parquet is preferred. JSONL, JSON-array, and CSV are also accepted as
+long as the file has a `prompt` column. The prompt content is forwarded
+verbatim to the agent environment, which owns parsing — encode structured
+prompts (conversation history, tool configs) as a single
+`json.dumps(task_data)` string per record.
+
+**Q: How does MTRL evaluation differ from LLM-as-Judge?**
+A: LLM-as-Judge scores a single response with a judge model. MTRL
+evaluation runs an end-to-end multi-turn rollout against an agent
+environment and scores the trajectory. Use MTRL evaluation when the model
+was trained with MTRL or when measuring multi-turn agent behaviour.
+
+## Troubleshooting
+
+### Evaluation fails with "agent_config is required"
+
+You hit Step 3b without providing an `agent_config`. Re-run the
+agent-environment-setup sub-flow (see Step 3b) and pass the resulting
+`AGENT_ENV` as `agent_config=...`.
+
+### Evaluation fails with "model is not MTRL-trained"
+
+The trainer-resolved path (Step 3a) requires that the attached training job
+was an MTRL run. If the job is SFT/DPO/RLVR, switch to one of the existing
+LLM-as-Judge or Custom Scorer evaluation types.

--- a/plugins/sagemaker-ai/skills/model-evaluation/scripts/eval_type_selector.py
+++ b/plugins/sagemaker-ai/skills/model-evaluation/scripts/eval_type_selector.py
@@ -1,0 +1,188 @@
+"""Auto-select the evaluation type from a training job's tags.
+
+This module implements the deterministic helper referenced as
+**Property 9 (MTRL Evaluation auto-selection)** in
+``.kiro/specs/mtrl-finetuning-skill/design.md``. It encodes the rule
+required by:
+
+* **R7.2** — When the model under evaluation was trained with the MTRL
+  technique, the Model_Evaluation Skill SHALL select MTRL Evaluation
+  automatically and confirm the choice with the user before generating
+  cells.
+* **R10.4** — The Planning Skill SHALL recommend ``MTRLEvaluator``-based
+  model evaluation when the plan's training step is MTRL, rather than
+  recommending LLM-as-Judge or Custom Scorer.
+
+The helper inspects a SageMaker training job's tags and decides whether
+the job was produced by an MTRL run. If so, the
+``model-evaluation`` skill (and the ``planning`` skill, transitively)
+defaults the evaluation type to the literal string
+``"MTRL Evaluation"``. The user still confirms before any cells are
+generated — this helper only computes the **default**.
+
+Returning ``None`` is a deliberate "no signal" answer: the caller falls
+back to its existing logic (typically prompting the user to choose
+between LLM-as-Judge and Custom Scorer). The helper is intentionally
+**conservative**: it requires both an MTRL-shaped value *and* a
+training-shaped key so that an unrelated tag like
+``description=mtrl-related-experiment`` does not trigger a false
+positive.
+
+This module is pure: no I/O, no network or AWS calls, no logging, and
+stdlib-only.
+"""
+
+from __future__ import annotations
+
+from typing import Iterator, Mapping
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: The string returned when the helper detects an MTRL training job.
+MTRL_EVAL_TYPE: str = "MTRL Evaluation"
+
+#: Substring (case-insensitive) that must appear in a tag value.
+_MTRL_VALUE_TOKEN: str = "mtrl"
+
+#: Substrings that mark the tag key as training-related.
+_TRAINING_KEY_TOKENS: tuple[str, ...] = ("recipe", "technique")
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _iter_tag_pairs(tags: object) -> Iterator[tuple[str, str]]:
+    """Yield ``(key, value)`` string pairs from either tag shape.
+
+    The SageMaker SDK exposes training-job tags in two shapes that we
+    must accept transparently:
+
+    1. A mapping like ``{"key": "value", ...}`` (dict-shaped).
+    2. A list of single-tag dicts like
+       ``[{"Key": "key", "Value": "value"}, ...]`` (list-shaped, the
+       boto3 / Coral wire shape).
+
+    This helper normalises both into an iterator of string pairs.
+    Non-string keys / values, malformed entries, or unrecognised tag
+    shapes are silently skipped.
+    """
+    if tags is None:
+        return
+
+    # Dict / mapping shape.
+    if isinstance(tags, Mapping):
+        for key, value in tags.items():
+            if isinstance(key, str) and isinstance(value, str):
+                yield key, value
+        return
+
+    # List-of-dicts shape (the boto3 ``Tags=[{Key,Value}, ...]`` form).
+    if isinstance(tags, (str, bytes)):
+        return
+
+    try:
+        iterator = iter(tags)  # type: ignore[arg-type]
+    except TypeError:
+        return
+
+    for entry in iterator:
+        if not isinstance(entry, Mapping):
+            continue
+        key = entry.get("Key")
+        if not isinstance(key, str):
+            key = entry.get("key")
+        value = entry.get("Value")
+        if not isinstance(value, str):
+            value = entry.get("value")
+        if isinstance(key, str) and isinstance(value, str):
+            yield key, value
+
+
+def _is_mtrl_signal(key: str, value: str) -> bool:
+    """Return ``True`` iff ``(key, value)`` indicates MTRL.
+
+    The detection rule is intentionally narrow:
+
+    * The value must contain the substring ``"mtrl"`` (case-insensitive).
+    * The key must contain at least one of the training-shaped tokens
+      (``"recipe"`` or ``"technique"``, case-insensitive).
+
+    Both halves are required to avoid false positives on unrelated
+    tags whose value happens to mention MTRL.
+    """
+    key_lower = key.lower()
+    value_lower = value.lower()
+
+    if _MTRL_VALUE_TOKEN not in value_lower:
+        return False
+
+    return any(token in key_lower for token in _TRAINING_KEY_TOKENS)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def auto_select_eval_type(training_job_tags: dict | list) -> str | None:
+    """Auto-select the evaluation type from a training job's tags.
+
+    The helper inspects ``training_job_tags`` and returns the literal
+    string ``"MTRL Evaluation"`` when the tags clearly indicate an MTRL
+    training run. Otherwise it returns ``None``, signalling to the
+    caller that no auto-selection was made and the existing
+    LLM-as-Judge / Custom Scorer prompt flow should run.
+
+    Detection rule (Property 9, conservative):
+
+    * Any tag whose **value** contains the substring ``"mtrl"``
+      (case-insensitive) **and** whose **key** contains at least one
+      of ``"recipe"`` or ``"technique"`` (case-insensitive).
+
+    Args:
+        training_job_tags: The tag collection attached to a SageMaker
+            training job. Accepted shapes:
+
+            * A ``dict`` mapping tag key to tag value.
+            * A ``list`` of single-tag dicts (the boto3 wire shape):
+              ``[{"Key": "...", "Value": "..."}, ...]``.
+
+            ``None``, empty containers, malformed entries, or any other
+            shape are treated as "no signal" and yield ``None``.
+
+    Returns:
+        ``"MTRL Evaluation"`` when at least one tag matches the
+        detection rule; ``None`` otherwise.
+
+    Examples:
+        >>> auto_select_eval_type(
+        ...     {"sagemaker:training_recipe": "finetuning_mtrl_grpo"}
+        ... )
+        'MTRL Evaluation'
+
+        >>> auto_select_eval_type([
+        ...     {"Key": "sagemaker-studio:hyperparameters:training_recipe",
+        ...      "Value": "finetuning_mtrl_central"},
+        ... ])
+        'MTRL Evaluation'
+
+        >>> auto_select_eval_type(
+        ...     {"sagemaker:training_recipe": "finetuning_sft_v2"}
+        ... ) is None
+        True
+
+        >>> auto_select_eval_type({"description": "mtrl-experiment"}) is None
+        True
+
+        >>> auto_select_eval_type(None) is None
+        True
+    """
+    for key, value in _iter_tag_pairs(training_job_tags):
+        if _is_mtrl_signal(key, value):
+            return MTRL_EVAL_TYPE
+
+    return None

--- a/plugins/sagemaker-ai/skills/planning/references/model-customization-plan.md
+++ b/plugins/sagemaker-ai/skills/planning/references/model-customization-plan.md
@@ -3,7 +3,8 @@
 A typical model customization workflow follows these steps in order:
 
 1. **Define Use Case** — Capture the business problem, users, and success criteria. _(Skill: use-case-specification)_
-2. **Finetuning Setup** — Choose a fine-tuning technique (SFT, DPO, or RLVR) and base model. _(Skill: finetuning-setup)_
+2. **Finetuning Setup** — Choose a fine-tuning technique (SFT, DPO, RLVR, or MTRL) and base model. _(Skill: finetuning-setup)_
+   - **MTRL note:** MTRL (Multi-Turn Reinforcement Learning) requires an agent environment (Bedrock AgentCore runtime or a custom Lambda-fronted agent). The agent environment is configured inside the `finetuning` skill during notebook generation — not in a separate plan step.
 3. **Evaluate Dataset** — Assess data quality, completeness, and format. _(Skill: dataset-evaluation)_
 4. **Transform Dataset** — Convert the dataset to the required format for the selected fine-tuning technique and base model. _(Skill: dataset-transformation)_
 5. **Fine-Tune Model** — Train a custom model using SageMaker. _(Skill: finetuning)_

--- a/plugins/sagemaker-ai/skills/planning/references/skill-routing-constraints.md
+++ b/plugins/sagemaker-ai/skills/planning/references/skill-routing-constraints.md
@@ -29,4 +29,15 @@
 - All dataset format changes MUST go through dataset-transformation.
   Do not write inline transformation code in other skills' notebooks.
 - All model/technique selection MUST go through finetuning-setup.
-  Do not resolve model IDs or select techniques ad-hoc.
+  Do not resolve model IDs or select techniques ad-hoc. This applies
+  equally to MTRL: MTRL technique selection MUST go through
+  finetuning-setup, consistent with SFT/DPO/RLVR.
+- Agent-environment configuration for MTRL is part of the `finetuning`
+  skill (and is reused by `model-evaluation` for base-model
+  evaluation). Do not split it into a separate plan step.
+
+## Evaluation Recommendations
+
+- When the training step is MTRL, recommend MTRL Evaluation
+  (`MultiTurnRLEvaluator`) rather than LLM-as-Judge or Custom Scorer.
+  See the model-evaluation skill for details.


### PR DESCRIPTION
## Summary

Adds **Multi-Turn Reinforcement Learning (MTRL)** as a fourth supported fine-tuning technique to the SageMaker AI model customization skills, alongside SFT, DPO, and RLVR. MTRL trains a model by letting it interact with an external agent environment (Bedrock AgentCore or a Lambda-fronted custom agent) over multiple turns, making it well-suited for agentic workflows (tool use, multi-step reasoning).

## What changed

The change spans seven skills under `plugins/sagemaker-ai/skills/`:

| Skill | Change |
| --- | --- |
| `planning` | Surface MTRL as a candidate technique; note agent-env setup happens in `finetuning`; recommend MTRL Evaluation when training step is MTRL |
| `finetuning-setup` | Recommend MTRL for agentic/multi-turn/tool-use cases; add `mtrl` to the `get_recipes.py` allowlist |
| `dataset-evaluation` | Detect/validate Parquet (PAR1 magic bytes) plus JSONL/JSON/CSV with a `prompt` column, unified under a new `mtrl_parquet` format label; warn on technique/format mismatch |
| `dataset-transformation` | Add MTRL Parquet target output (`.parquet`, single `prompt` string column) |
| `finetuning` | MTRL notebook template (`mtrl_example.md`), agent-environment setup sub-flow (`agent_environment_setup.md`) for Bedrock AgentCore (discover via `aws___call_aws`) or a custom Lambda forwarder template |
| `model-evaluation` | MTRL Evaluation via `MultiTurnRLEvaluator` (trainer-resolved or base-model + `agent_config`) |
| `model-deployment` | MTRL SageMaker (`ModelBuilder`) and Bedrock (`BedrockModelBuilder`) deployment pathways |

Reference notebooks used as source of truth:
- `mtrl_finetuning_example_notebook_v3_prod.ipynb` (training)
- `mtrl_dogfooding_notebook.ipynb` (train → eval → deploy)
- `dataset_format_detector.py` (Parquet detection)

## Backward compatibility

- Existing SFT/DPO/RLVR flows are unchanged — the agent-environment sub-flow is gated on `technique == "mtrl"`.
- The format detector's existing 11 format branches are untouched; the new `mtrl_parquet` label only applies to `.parquet` files and to JSONL/JSON/CSV that the existing classifier returns `UNKNOWN` for.
- The existing OSS/Nova LoRA deployment pathways are unchanged.
- The existing EULA experience is unchanged (MTRL participates in the same Meta vs non-Meta flow).

## Testing

- All Python helpers (`agent_env_validator.py`, `bedrock_deploy_selector.py`, `instance_recommender.py`, `eval_type_selector.py`) carry doctests and pass `getDiagnostics` with no errors.
- Format detector smoke-tested across valid/invalid Parquet, prompt-only JSONL, Nova SFT (regression), CSV, and JSON-array inputs.

---
X-AI-Prompt: Add a new MTRL (Multi-Turn Reinforcement Learning) fine-tuning technique skill to the SageMaker AI agent-plugins skills
X-AI-Tool: Kiro
