### PR TITLE
docs(sagemaker-ai): update README install instructions for nova-forge-beta branch

### DIFF
--- a/plugins/sagemaker-ai/README.md
+++ b/plugins/sagemaker-ai/README.md
@@ -42,24 +42,26 @@ This plugin brings deep AWS AI/ML expertise directly into your coding assistant,
 Run in your terminal:
 
 ```
-claude plugins marketplace add awslabs/agent-plugins
+claude plugins marketplace add "https://github.com/awslabs/agent-plugins#sagemaker-ai-nova-forge-beta"
 claude plugins install sagemaker-ai@agent-plugins-for-aws
 ```
 
 Or if you're already inside Claude Code, run:
 
 ```
-/plugin marketplace add awslabs/agent-plugins
+/plugin marketplace add https://github.com/awslabs/agent-plugins#sagemaker-ai-nova-forge-beta
 /plugin install sagemaker-ai@agent-plugins-for-aws
 ```
 
 ### Cursor
 
-Install from the [Cursor Marketplace](https://cursor.com/marketplace/aws/sagemaker-ai) by selecting **Add to Cursor**, or run within Cursor:
+Install using the [Skills CLI](https://github.com/vercel-labs/skills):
 
 ```
-/add-plugin sagemaker-ai
+npx skills add https://github.com/awslabs/agent-plugins/tree/sagemaker-ai-nova-forge-beta/plugins/sagemaker-ai/skills --all --agent cursor --copy
 ```
+
+Then copy .mcp.json to your project root for the MCP server.
 
 ### Other Agents
 
@@ -68,7 +70,7 @@ For other agents (Kiro, etc.), install the skills and MCP server manually.
 **Install skills** using the [Skills CLI](https://github.com/vercel-labs/skills). For example, to install for Kiro:
 
 ```
-npx skills add https://github.com/awslabs/agent-plugins/tree/main/plugins/sagemaker-ai/skills --all --agent kiro-cli --copy
+npx skills add https://github.com/awslabs/agent-plugins/tree/sagemaker-ai-nova-forge-beta/plugins/sagemaker-ai/skills --all --agent kiro-cli --copy
 ```
 
 Replace `kiro-cli` with your agent if different. See [Skills supported agents](https://github.com/vercel-labs/skills#supported-agents).


### PR DESCRIPTION
## Summary

- Updated Claude Code install to use marketplace URL with `sagemaker-ai-nova-forge-beta` branch reference
- Replaced Cursor Marketplace install with Skills CLI approach using the beta branch
- Updated Other Agents skills URL from `main` to `sagemaker-ai-nova-forge-beta` branch

## Test plan

- [x] Verify Claude Code install commands work with the new marketplace URL
- [x] Verify Cursor Skills CLI command installs correctly
- [x] Verify Kiro skills CLI command resolves the beta branch