### PR TITLE
docs(databases-on-aws): reflect native DSQL JSON/JSONB column support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -152,7 +152,7 @@
       "name": "databases-on-aws",
       "source": "./plugins/databases-on-aws",
       "tags": ["aws", "database", "aurora", "dsql", "serverless", "postgresql"],
-      "version": "1.1.0"
+      "version": "1.2.0"
     },
     {
       "category": "deployment",

--- a/plugins/databases-on-aws/.claude-plugin/plugin.json
+++ b/plugins/databases-on-aws/.claude-plugin/plugin.json
@@ -22,5 +22,5 @@
   "license": "Apache-2.0",
   "name": "databases-on-aws",
   "repository": "https://github.com/awslabs/agent-plugins",
-  "version": "1.1.0"
+  "version": "1.2.0"
 }

--- a/plugins/databases-on-aws/.codex-plugin/plugin.json
+++ b/plugins/databases-on-aws/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "databases-on-aws",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Expert database guidance for the AWS database portfolio. Design schemas, execute queries, handle migrations, and choose the right database for your workload.",
   "author": {
     "name": "Amazon Web Services",

--- a/plugins/databases-on-aws/skills/dsql/SKILL.md
+++ b/plugins/databases-on-aws/skills/dsql/SKILL.md
@@ -195,7 +195,7 @@ See [scripts/README.md](../../scripts/README.md) for usage and hook configuratio
 - MUST include tenant_id in all tables
 - MUST use `CREATE INDEX ASYNC` exclusively
 - MUST issue each DDL in its own transact call: `transact(["CREATE TABLE ..."])`
-- MUST serialize arrays as JSONB (DSQL does not support array column types); expand at query time with `jsonb_array_elements_text(data)`
+- MUST serialize arrays as JSONB; expand at query time with `jsonb_array_elements_text(data)`
 
 ### Workflow 2: Safe Data Migration
 

--- a/plugins/databases-on-aws/skills/dsql/SKILL.md
+++ b/plugins/databases-on-aws/skills/dsql/SKILL.md
@@ -195,7 +195,7 @@ See [scripts/README.md](../../scripts/README.md) for usage and hook configuratio
 - MUST include tenant_id in all tables
 - MUST use `CREATE INDEX ASYNC` exclusively
 - MUST issue each DDL in its own transact call: `transact(["CREATE TABLE ..."])`
-- MUST serialize arrays as TEXT or JSON; cast back at query time (`string_to_array(text, ',')` or `jsonb_array_elements_text(json::jsonb)`)
+- MUST serialize arrays as JSONB (DSQL does not support array column types); expand at query time with `jsonb_array_elements_text(data)`
 
 ### Workflow 2: Safe Data Migration
 

--- a/plugins/databases-on-aws/skills/dsql/references/development-guide.md
+++ b/plugins/databases-on-aws/skills/dsql/references/development-guide.md
@@ -54,7 +54,7 @@ effortless scaling, multi-region viability, among other advantages.
 ### Schema Design Rules
 
 - MUST verify column types via `awsknowledge`: `aurora dsql supported data types` or the [DSQL supported data types list](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility-supported-data-types.html)
-- MUST serialize arrays as JSONB (DSQL does not support array column types); expand at query time via `jsonb_array_elements_text(data)`
+- MUST serialize arrays as JSONB; expand at query time via `jsonb_array_elements_text(data)`
 - ALWAYS include tenant_id in tables for multi-tenant isolation
 - SHOULD create async indexes for tenant_id and common query patterns
 
@@ -125,7 +125,7 @@ UPDATE table SET c = 'default' WHERE c IS NULL;        ← AFTER ADD COLUMN
 
 **MUST verify** column types against the [DSQL supported data types docs](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility-supported-data-types.html) or via `awsknowledge`: `aurora dsql supported data types` — the supported set evolves, so do not treat any static list as exhaustive.
 
-Arrays and `INET` are **[runtime-only](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility-supported-data-types.html#working-with-postgresql-compatibility-query-runtime)** — cast at query time. `JSON` and `JSONB` are supported as column types; prefer `JSONB` for queryable structured data.
+Arrays and `INET` are **[runtime-only](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility-supported-data-types.html#working-with-postgresql-compatibility-query-runtime)** — cast at query time. For structured data, prefer `JSONB` over `JSON` for queryable fields.
 
 ### Supported Key
 

--- a/plugins/databases-on-aws/skills/dsql/references/development-guide.md
+++ b/plugins/databases-on-aws/skills/dsql/references/development-guide.md
@@ -13,8 +13,7 @@ effortless scaling, multi-region viability, among other advantages.
 - **REQUIRED: Follow DDL Guidelines** - Refer to [DDL Rules](#schema-ddl-rules)
 - **SHALL repeatedly generate fresh tokens** - Refer to [Connection Limits](auth/authentication-guide.md#connection-rules)
 - **ALWAYS use ASYNC indexes** - `CREATE INDEX ASYNC` is mandatory
-- **MUST serialize arrays as TEXT or JSON** - see [Schema Design Rules](#schema-design-rules)
-- **MUST cast to `JSONB` at query time** for JSONB operators — see [Supported Data Types](#supported-data-types)
+- **MUST serialize arrays as JSONB** - see [Schema Design Rules](#schema-design-rules)
 - **ALWAYS Batch within row limit** - maintain transaction limits (verify via `awsknowledge`: `aurora dsql transaction limits`)
 - **REQUIRED: Build and sanitize all SQL with `safe_query.build()`** - See [Input Validation](../mcp/tools/input-validation.md#required-pattern)
 - **MUST follow correct Application Layer Patterns** - when multi-tenant isolation or application referential integrity are required; refer to [Application Layer Patterns](#application-layer-patterns)
@@ -55,7 +54,7 @@ effortless scaling, multi-region viability, among other advantages.
 ### Schema Design Rules
 
 - MUST verify column types via `awsknowledge`: `aurora dsql supported data types` or the [DSQL supported data types list](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility-supported-data-types.html)
-- MUST serialize arrays as TEXT or JSON; cast back at query time via `string_to_array(text, ',')` or `jsonb_array_elements_text(json::jsonb)`
+- MUST serialize arrays as JSONB (DSQL does not support array column types); expand at query time via `jsonb_array_elements_text(data)`
 - ALWAYS include tenant_id in tables for multi-tenant isolation
 - SHOULD create async indexes for tenant_id and common query patterns
 
@@ -126,7 +125,7 @@ UPDATE table SET c = 'default' WHERE c IS NULL;        ← AFTER ADD COLUMN
 
 **MUST verify** column types against the [DSQL supported data types docs](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility-supported-data-types.html) or via `awsknowledge`: `aurora dsql supported data types` — the supported set evolves, so do not treat any static list as exhaustive.
 
-`JSONB`, arrays, and `INET` are **[runtime-only](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility-supported-data-types.html#working-with-postgresql-compatibility-query-runtime)** — cast at query time
+Arrays and `INET` are **[runtime-only](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility-supported-data-types.html#working-with-postgresql-compatibility-query-runtime)** — cast at query time. `JSON` and `JSONB` are supported as column types; prefer `JSONB` for queryable structured data.
 
 ### Supported Key
 

--- a/plugins/databases-on-aws/skills/dsql/references/examples/patterns.md
+++ b/plugins/databases-on-aws/skills/dsql/references/examples/patterns.md
@@ -131,35 +131,30 @@ INSERT INTO distributors VALUES (nextval('order_seq'), 'nothing');
 
 ## Runtime-Only Types
 
-`JSONB`, arrays, and `INET` are [runtime-only](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility-supported-data-types.html#working-with-postgresql-compatibility-query-runtime) — not valid as column types.
+Arrays and `INET` are [runtime-only](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility-supported-data-types.html#working-with-postgresql-compatibility-query-runtime) — not valid as column types. `JSON` and `JSONB` ARE supported as column types; prefer `JSONB` for queryable structured data.
 
-- **MUST** serialize arrays as `TEXT` or `JSON` — use `TEXT` (comma-separated) for homogeneous short strings; use `JSON` when elements may contain commas or aren't homogeneous
-- **MUST** cast back at query time — `string_to_array(text, ',')` for TEXT, `jsonb_array_elements_text(json::jsonb)` for JSON
+- **MUST** serialize arrays as `JSONB` — DSQL does not support array column types like `TEXT[]`
+- **MAY** use `jsonb_array_elements_text(data)` to expand a JSONB array at query time
 
 ```javascript
-function toTextArray(values) {
-  return values.join(',');
-}
-
-function fromTextArray(textValue) {
-  return textValue ? textValue.split(',').map(v => v.trim()) : [];
-}
-
-const categoriesText = toTextArray(['backend', 'api', 'database']);
-await pool.query('INSERT INTO projects (project_id, categories) VALUES ($1, $2)', [projectId, categoriesText]);
+const categories = ['backend', 'api', 'database'];
+await pool.query(
+  'INSERT INTO projects (project_id, categories) VALUES ($1, $2::jsonb)',
+  [projectId, JSON.stringify(categories)],
+);
 
 await pool.query(
-  'INSERT INTO user_settings (user_id, preferences) VALUES ($1, $2)',
-  [userId, { theme: 'dark', notifications: true }],
+  'INSERT INTO user_settings (user_id, preferences) VALUES ($1, $2::jsonb)',
+  [userId, JSON.stringify({ theme: 'dark', notifications: true })],
 );
 ```
 
 Query-time operations:
 
 ```sql
-SELECT user_id, preferences::jsonb->>'theme' AS theme
+SELECT user_id, preferences->>'theme' AS theme
 FROM user_settings
-WHERE preferences::jsonb->>'notifications' = 'true';
+WHERE preferences->>'notifications' = 'true';
 
-SELECT project_id, string_to_array(categories, ',') AS category_array FROM projects;
+SELECT project_id, jsonb_array_elements_text(categories) AS category FROM projects;
 ```

--- a/plugins/databases-on-aws/skills/dsql/references/examples/patterns.md
+++ b/plugins/databases-on-aws/skills/dsql/references/examples/patterns.md
@@ -129,11 +129,11 @@ INSERT INTO distributors VALUES (nextval('order_seq'), 'nothing');
 
 ---
 
-## Runtime-Only Types
+## Arrays and Structured Data
 
-Arrays and `INET` are [runtime-only](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility-supported-data-types.html#working-with-postgresql-compatibility-query-runtime) — not valid as column types. `JSON` and `JSONB` ARE supported as column types; prefer `JSONB` for queryable structured data.
+Arrays and `INET` are [runtime-only](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility-supported-data-types.html#working-with-postgresql-compatibility-query-runtime) — not valid as column types. For structured data, prefer `JSONB` over `JSON` for queryable fields.
 
-- **MUST** serialize arrays as `JSONB` — DSQL does not support array column types like `TEXT[]`
+- **MUST** serialize arrays as `JSONB`
 - **MAY** use `jsonb_array_elements_text(data)` to expand a JSONB array at query time
 
 ```javascript

--- a/plugins/databases-on-aws/skills/dsql/references/examples/schema.md
+++ b/plugins/databases-on-aws/skills/dsql/references/examples/schema.md
@@ -20,8 +20,8 @@ CREATE TABLE IF NOT EXISTS orders (
   order_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   tenant_id VARCHAR(255) NOT NULL,
   status VARCHAR(50) NOT NULL,
-  tags TEXT,
-  metadata TEXT,
+  tags JSONB,
+  metadata JSONB,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 ```

--- a/plugins/databases-on-aws/skills/dsql/references/mysql-migrations/full-example.md
+++ b/plugins/databases-on-aws/skills/dsql/references/mysql-migrations/full-example.md
@@ -45,7 +45,7 @@ transact([
      price DECIMAL(10,2) NOT NULL,
      category VARCHAR(255) DEFAULT 'other' CHECK (category IN ('electronics', 'clothing', 'food', 'other')),
      tags TEXT,
-     metadata JSON,
+     metadata JSONB,
      stock INTEGER DEFAULT 0 CHECK (stock >= 0),
      is_active BOOLEAN DEFAULT true,
      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -70,7 +70,7 @@ transact(["CREATE INDEX ASYNC idx_products_category ON products(tenant_id, categ
 | `MEDIUMTEXT`                  | `TEXT`                                                                                                                                                     |
 | `ENUM(...)`                   | `VARCHAR(255)` with `CHECK` constraint                                                                                                                     |
 | `SET(...)`                    | `TEXT` (comma-separated)                                                                                                                                   |
-| `JSON`                        | `JSON`                                                                                                                                                     |
+| `JSON`                        | `JSONB` (preferred) or `JSON` — `JSONB` for queryable structured data; `JSON` preserves key order and whitespace                                           |
 | `UNSIGNED`                    | `CHECK (col >= 0)`                                                                                                                                         |
 | `TINYINT(1)`                  | `BOOLEAN`                                                                                                                                                  |
 | `DATETIME`                    | `TIMESTAMP`                                                                                                                                                |

--- a/plugins/databases-on-aws/skills/dsql/references/mysql-migrations/type-mapping.md
+++ b/plugins/databases-on-aws/skills/dsql/references/mysql-migrations/type-mapping.md
@@ -97,7 +97,7 @@ Map MySQL data types to their DSQL equivalents.
 
 | MySQL Type     | DSQL Equivalent                                           | Notes                                                                                                |
 | -------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| JSON           | `JSON`                                                    | Direct equivalent                                                                                    |
+| JSON           | `JSONB` (preferred) or `JSON`                             | Prefer `JSONB` for queryable structured data; use `JSON` to preserve key order and whitespace        |
 | AUTO_INCREMENT | UUID with gen_random_uuid(), IDENTITY column, or SEQUENCE | See [AUTO_INCREMENT Migration](ddl-auto-increment.md#auto_increment-migration) for all three options |
 
 ---

--- a/plugins/databases-on-aws/skills/dsql/references/onboarding.md
+++ b/plugins/databases-on-aws/skills/dsql/references/onboarding.md
@@ -35,7 +35,7 @@ These guidelines apply when users say "Get started with DSQL" or similar phrases
   - Example:
     - "What column names would you like in this table?"
     - "What is the column name of the primary key?"
-    - "Should this column be `JSON`, `JSONB`, or `TEXT`? (`JSONB` is recommended for queryable structured data.)"
+    - "Should this column be `JSONB` or `JSON`? (`JSONB` is recommended for queryable structured data.)"
 
 **Examples:**
 
@@ -252,8 +252,8 @@ cargo add aws-sdk-dsql tokio --features full
 - If yes, MUST verify DSQL compatibility:
   - No SERIAL types (use `GENERATED AS IDENTITY` with sequences, or UUID)
   - No foreign keys (implement in application)
-  - Serialize arrays as `JSONB` (DSQL does not support array column types); expand at query time with `jsonb_array_elements_text(data)`
-  - `JSON` and `JSONB` columns are supported natively; prefer `JSONB` for queryable structured data
+  - Serialize arrays as `JSONB`; expand at query time with `jsonb_array_elements_text(data)`
+  - For structured data, prefer `JSONB` over `JSON` for queryable fields
   - Verify column types against the [supported data types list](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility-supported-data-types.html)
   - Reference [`./development-guide.md`](./development-guide.md) for full constraints
 
@@ -351,7 +351,7 @@ Let them know you're ready to help with more:
 **ALWAYS follow these rules:**
 
 1. **Indexes:** Use `CREATE INDEX ASYNC` - synchronous index creation not supported
-2. **Runtime-only types:** Arrays must be serialized as `JSONB` (DSQL does not support array column types). `JSON` and `JSONB` columns are supported natively.
+2. **Arrays:** Serialize as `JSONB`; expand at query time with `jsonb_array_elements_text(data)`
 3. **Referential Integrity:** Implement foreign key validation in application code
 4. **DDL Operations:** Execute one DDL per transaction, no mixing with DML
 5. **Transaction Limits:** Maximum 3,000 row modifications, 10 MiB data size per transaction

--- a/plugins/databases-on-aws/skills/dsql/references/onboarding.md
+++ b/plugins/databases-on-aws/skills/dsql/references/onboarding.md
@@ -35,7 +35,7 @@ These guidelines apply when users say "Get started with DSQL" or similar phrases
   - Example:
     - "What column names would you like in this table?"
     - "What is the column name of the primary key?"
-    - "Would you like to store this in a `JSON` column, or serialize as TEXT?"
+    - "Should this column be `JSON`, `JSONB`, or `TEXT`? (`JSONB` is recommended for queryable structured data.)"
 
 **Examples:**
 
@@ -252,8 +252,8 @@ cargo add aws-sdk-dsql tokio --features full
 - If yes, MUST verify DSQL compatibility:
   - No SERIAL types (use `GENERATED AS IDENTITY` with sequences, or UUID)
   - No foreign keys (implement in application)
-  - Serialize arrays as TEXT or JSON; cast back at query time (`string_to_array(text, ',')` / `jsonb_array_elements_text(json::jsonb)`)
-  - Cast to `JSONB` at query time for JSONB operators (`JSONB` is not a valid column type)
+  - Serialize arrays as `JSONB` (DSQL does not support array column types); expand at query time with `jsonb_array_elements_text(data)`
+  - `JSON` and `JSONB` columns are supported natively; prefer `JSONB` for queryable structured data
   - Verify column types against the [supported data types list](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility-supported-data-types.html)
   - Reference [`./development-guide.md`](./development-guide.md) for full constraints
 
@@ -351,7 +351,7 @@ Let them know you're ready to help with more:
 **ALWAYS follow these rules:**
 
 1. **Indexes:** Use `CREATE INDEX ASYNC` - synchronous index creation not supported
-2. **Runtime-only types:** Serialize arrays as TEXT or JSON; cast to `JSONB` at query time for JSONB operators
+2. **Runtime-only types:** Arrays must be serialized as `JSONB` (DSQL does not support array column types). `JSON` and `JSONB` columns are supported natively.
 3. **Referential Integrity:** Implement foreign key validation in application code
 4. **DDL Operations:** Execute one DDL per transaction, no mixing with DML
 5. **Transaction Limits:** Maximum 3,000 row modifications, 10 MiB data size per transaction

--- a/plugins/databases-on-aws/skills/dsql/references/troubleshooting.md
+++ b/plugins/databases-on-aws/skills/dsql/references/troubleshooting.md
@@ -92,11 +92,11 @@ See [full list of unsupported features](https://docs.aws.amazon.com/aurora-dsql/
 
 ### Error: "Datatype array not supported"
 
-**Cause:** Using TEXT[] or other array types
+**Cause:** Using `TEXT[]` or other array column types
 **Solution:**
 
-1. Change column to TEXT and store as comma-separated (`"tag1,tag2,tag3"`), or use a `JSON` column (`tags JSON`)
-2. Deserialize in application layer; cast to `JSONB` at query time for JSONB operators
+1. Change the column to `JSONB` (`tags JSONB`) and serialize the array as a JSONB array
+2. At query time, expand it with `jsonb_array_elements_text(tags)`
 
 ### Error: "Please use CREATE INDEX ASYNC"
 

--- a/tools/evals/databases-on-aws/README.md
+++ b/tools/evals/databases-on-aws/README.md
@@ -88,7 +88,7 @@ python tools/evals/databases-on-aws/dsql/scripts/run_functional_evals.py \
 | 3. Index limits                | MCP delegation        | regex     | Calls `awsknowledge`, cites 24 index limit, suggests alternatives                                         |
 | 4. Python connection           | Language routing      | regex     | Recommends DSQL Python Connector, IAM auth, 15-min token expiry, SSL                                      |
 | 5. Column type change          | DDL migration routing | regex     | Table Recreation Pattern, DROP TABLE warning, batching, user confirmation                                 |
-| 6. JSON column storage         | Type guidance         | LLM judge | Recommends `JSONB` (or `JSON`) as the column type — both are supported natively in DSQL                   |
+| 6. JSON column storage         | Type guidance         | LLM judge | Recommends `JSONB` (or `JSON`) as the column type for queryable structured data                           |
 | 7. Array storage               | Type guidance         | LLM judge | Flags `TEXT[]` / array column as unsupported, recommends storing the array as `JSONB`                     |
 | 8. INACTIVE cluster error      | Troubleshooting       | LLM judge | Identifies INACTIVE state, uses `aws dsql get-cluster` to poll until `ACTIVE`, retries afterwards         |
 | 9. Backup on IDLE/INACTIVE     | Troubleshooting       | LLM judge | Identifies `FailedPrecondition`, connects to wake cluster to ACTIVE, retries backup                       |

--- a/tools/evals/databases-on-aws/README.md
+++ b/tools/evals/databases-on-aws/README.md
@@ -88,8 +88,8 @@ python tools/evals/databases-on-aws/dsql/scripts/run_functional_evals.py \
 | 3. Index limits                | MCP delegation        | regex     | Calls `awsknowledge`, cites 24 index limit, suggests alternatives                                         |
 | 4. Python connection           | Language routing      | regex     | Recommends DSQL Python Connector, IAM auth, 15-min token expiry, SSL                                      |
 | 5. Column type change          | DDL migration routing | regex     | Table Recreation Pattern, DROP TABLE warning, batching, user confirmation                                 |
-| 6. JSON column storage         | Type guidance         | LLM judge | Explains `::jsonb` cast, does not recommend `JSONB` as a column type                                      |
-| 7. Array storage               | Type guidance         | LLM judge | Flags `TEXT[]` / array column as unsupported, recommends TEXT or `JSON` column                            |
+| 6. JSON column storage         | Type guidance         | LLM judge | Recommends `JSONB` (or `JSON`) as the column type — both are supported natively in DSQL                   |
+| 7. Array storage               | Type guidance         | LLM judge | Flags `TEXT[]` / array column as unsupported, recommends storing the array as `JSONB`                     |
 | 8. INACTIVE cluster error      | Troubleshooting       | LLM judge | Identifies INACTIVE state, uses `aws dsql get-cluster` to poll until `ACTIVE`, retries afterwards         |
 | 9. Backup on IDLE/INACTIVE     | Troubleshooting       | LLM judge | Identifies `FailedPrecondition`, connects to wake cluster to ACTIVE, retries backup                       |
 | 10. Loader stuck at 3K rec/s   | Data loading          | LLM judge | Identifies partition-constrained fresh table, advises to keep running, does NOT recommend more workers    |

--- a/tools/evals/databases-on-aws/dsql/dsql_lint_eval_results.md
+++ b/tools/evals/databases-on-aws/dsql/dsql_lint_eval_results.md
@@ -5,6 +5,8 @@
 **dsql-lint version:** 0.1.4
 **Evaluation method:** Manual behavioral comparison — subagent run with skill loaded vs. subagent run without skill. Automated grading for these evals is not yet wired into `run_functional_evals.py`; PASS/FAIL is a human assessment of transcripts against the expectations in `dsql_lint_evals.json`.
 
+> **Historical note:** This eval was run when DSQL did not support `JSONB` as a column type, so the skill's "JSON → TEXT" rewrite was correct at the time and the baseline's `JSONB` recommendation was a hallucination. DSQL has since added native `JSON` and `JSONB` support; later `dsql-lint` versions accept both. The pass/fail judgments here are preserved as-is to keep the snapshot accurate.
+
 ## Summary
 
 | Eval | Scenario                  | With Skill | Baseline        | Delta                                                           |

--- a/tools/evals/databases-on-aws/dsql/evals.json
+++ b/tools/evals/databases-on-aws/dsql/evals.json
@@ -64,22 +64,22 @@
     {
       "id": 6,
       "prompt": "I need to store a JSON preferences blob per user in my DSQL users table. How should I model that column, and how do I query fields inside it?",
-      "expected_output": "Recommends either JSON or TEXT as a valid column type. Explains that JSONB is runtime-only and must be cast (preferences::jsonb->>'key') at query time for JSONB operators.",
+      "expected_output": "Recommends JSONB (preferred for queryable structured data) or JSON as the column type. Shows JSONB operator usage (preferences->>'key', preferences @> '{...}'::jsonb) for querying.",
       "files": [],
       "expectations": [
-        "Mentions casting to jsonb at query time for JSONB operators",
-        "Does NOT claim JSONB is a valid column type (JSONB is runtime-only)"
+        "Recommends JSONB (or JSON) as the column type — DSQL supports both natively",
+        "Demonstrates JSONB operator usage for querying fields inside the column"
       ],
       "llm_judge": true
     },
     {
       "id": 7,
       "prompt": "I want to store a tags array per project in DSQL (e.g. ['backend','database','api']). Can I use TEXT[] for that?",
-      "expected_output": "Indicates TEXT[] / array column type is not supported in DSQL. Recommends storing arrays as TEXT (comma-separated) or inside a JSON column.",
+      "expected_output": "Indicates TEXT[] / array column type is not supported in DSQL. Recommends storing the array as a JSONB column, with jsonb_array_elements_text() to expand it at query time.",
       "files": [],
       "expectations": [
         "Indicates TEXT[] or array column type is not supported in DSQL",
-        "Recommends storing arrays as TEXT (comma-separated) or inside a JSON column"
+        "Recommends storing arrays as JSONB (and ideally mentions jsonb_array_elements_text for query-time expansion)"
       ],
       "llm_judge": true
     },

--- a/tools/evals/databases-on-aws/dsql/evals.json
+++ b/tools/evals/databases-on-aws/dsql/evals.json
@@ -67,7 +67,7 @@
       "expected_output": "Recommends JSONB (preferred for queryable structured data) or JSON as the column type. Shows JSONB operator usage (preferences->>'key', preferences @> '{...}'::jsonb) for querying.",
       "files": [],
       "expectations": [
-        "Recommends JSONB (or JSON) as the column type — DSQL supports both natively",
+        "Recommends JSONB (or JSON) as the column type",
         "Demonstrates JSONB operator usage for querying fields inside the column"
       ],
       "llm_judge": true


### PR DESCRIPTION
## Summary

DSQL now supports `JSON` and `JSONB` as column types natively, so the "JSONB is not a valid column type" / "store JSON as TEXT" guidance throughout the `databases-on-aws` DSQL skill is outdated. Array column types (`TEXT[]`) are still unsupported — the recommended workaround is now JSONB (was TEXT/comma-separated).

Verified against a live cluster: JSONB column DDL, `'{...}'::jsonb` casts, `->`/`->>` operators, `jsonb_array_length`, and `jsonb_array_elements_text` all work end-to-end. `TEXT[]` is still rejected.

### Skill updates (`plugins/databases-on-aws/skills/dsql`)

- `SKILL.md`: array guidance now JSONB, not "TEXT or JSON"
- `references/development-guide.md`: drop "cast to `JSONB` at query time" from the best-practices summary; remove `JSONB` from the runtime-only list (`JSONB` is now a column type, not just a runtime type)
- `references/examples/patterns.md`: rewrite the Data Serialization example to use JSONB end-to-end (replacing the comma-separated TEXT helpers and `JSON.stringify`-into-TEXT pattern)
- `references/onboarding.md`: update the intake question and migration checklist
- `references/troubleshooting.md`: array error solution now points to JSONB instead of TEXT/comma-separated

### Eval updates (`tools/evals/databases-on-aws`)

- `evals.json`: eval 6 now expects JSONB recommendation (was: NOT JSONB); eval 7 expects JSONB array storage (was: TEXT/comma-separated)
- `README.md`: corresponding rows in the eval summary table
- `dsql_lint_eval_results.md`: add a Historical Note at the top clarifying that the snapshot pre-dates JSON/JSONB support — the body is preserved as-is so the snapshot stays accurate

## Test plan

- [x] Manual sweep across `plugins/databases-on-aws` and `tools/evals/databases-on-aws` for stale "JSONB is not supported" / "store JSON as TEXT" guidance — all updated
- [x] Verified JSONB column behavior end-to-end on a live DSQL cluster
- [ ] **Could not run `mise run build` locally — no `mise` in this environment.** Please verify formatting/lint in CI before merging.
- [ ] Re-run the dsql functional evals to confirm the new expected outputs are matched

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agent-plugins/blob/main/LICENSE).
