### PR TITLE
fix(databases-on-aws): renumber duplicate Workflow 9 in dsql skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -152,7 +152,7 @@
       "name": "databases-on-aws",
       "source": "./plugins/databases-on-aws",
       "tags": ["aws", "database", "aurora", "dsql", "serverless", "postgresql"],
-      "version": "1.3.0"
+      "version": "1.3.1"
     },
     {
       "category": "deployment",

--- a/plugins/databases-on-aws/.claude-plugin/plugin.json
+++ b/plugins/databases-on-aws/.claude-plugin/plugin.json
@@ -22,5 +22,5 @@
   "license": "Apache-2.0",
   "name": "databases-on-aws",
   "repository": "https://github.com/awslabs/agent-plugins",
-  "version": "1.3.0"
+  "version": "1.3.1"
 }

--- a/plugins/databases-on-aws/.codex-plugin/plugin.json
+++ b/plugins/databases-on-aws/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "databases-on-aws",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Expert database guidance for the AWS database portfolio. Design schemas, execute queries, handle migrations, and choose the right database for your workload.",
   "author": {
     "name": "Amazon Web Services",

--- a/plugins/databases-on-aws/skills/dsql/SKILL.md
+++ b/plugins/databases-on-aws/skills/dsql/SKILL.md
@@ -279,11 +279,11 @@ MUST load all four reference files at Phase 0: [query-plan/plan-interpretation.m
 
 **Safety.** Plan capture uses `readonly_query` exclusively. Rewrite DML to SELECT for plan capture. **MUST NOT** use `transact --allow-writes` for plan capture.
 
-### Workflow 9: Full PostgreSQL → DSQL Schema Migration
+### Workflow 10: Full PostgreSQL → DSQL Schema Migration
 
 MUST load [pg-migrations/type-mapping.md](references/pg-migrations/type-mapping.md) and [pg-migrations/schema-objects.md](references/pg-migrations/schema-objects.md). Run `dsql-lint(fix=true)` first for mechanical fixes, then apply semantic conversions from the pg-migrations references for unfixable diagnostics and patterns the linter cannot handle. Re-lint the final output before deploying.
 
-### Workflow 10: ORM Migration (Django/Hibernate/Rails)
+### Workflow 11: ORM Migration (Django/Hibernate/Rails)
 
 Load [orm-guides/overview.md](references/orm-guides/overview.md) for adapter names and framework-specific gotchas.
 


### PR DESCRIPTION
## Summary

Merging #168 produced two `Workflow 9` headings in `plugins/databases-on-aws/skills/dsql/SKILL.md`. Renumber the PG-migration entries to clear the collision.

- `Workflow 9: Query Plan Explainability` — kept at 9 (the `Workflow 9 Phase 0` cross-reference at SKILL.md:133 and `tools/evals/databases-on-aws/dsql/scripts/run_query_explainability_evals.py` already point here).
- `Workflow 9: Full PostgreSQL → DSQL Schema Migration` → **Workflow 10**
- `Workflow 10: ORM Migration (Django/Hibernate/Rails)` → **Workflow 11**

Bump `databases-on-aws` plugin version 1.3.0 → 1.3.1 (patch, doc-only fix) in:
- `plugins/databases-on-aws/.claude-plugin/plugin.json`
- `plugins/databases-on-aws/.codex-plugin/plugin.json`
- `.claude-plugin/marketplace.json`

## Test plan

- [x] `mise run lint` — clean
- [x] `mise run fmt:check` — clean
- [x] `mise run validate` — clean
- [x] Verified no other workflow numbers collide (`Workflow 1`–`8` unique, `Workflow 9` now refers only to Query Plan Explainability)
- [x] Verified all `Workflow 9` cross-references in evals/scripts still point at the correct (Query Plan) workflow

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agent-plugins/blob/main/LICENSE).