### PR TITLE
fix: Fixes a YAML frontmatter parse error in the sagemaker-ai plugin'…

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -192,7 +192,7 @@
       "name": "sagemaker-ai",
       "source": "./plugins/sagemaker-ai",
       "tags": ["aws", "sagemaker", "machine-learning", "generative-ai"],
-      "version": "1.2.0"
+      "version": "1.2.1"
     }
   ]
 }

--- a/plugins/sagemaker-ai/.claude-plugin/plugin.json
+++ b/plugins/sagemaker-ai/.claude-plugin/plugin.json
@@ -18,5 +18,5 @@
   "license": "Apache-2.0",
   "name": "sagemaker-ai",
   "repository": "https://github.com/awslabs/agent-plugins",
-  "version": "1.2.0"
+  "version": "1.2.1"
 }

--- a/plugins/sagemaker-ai/.codex-plugin/plugin.json
+++ b/plugins/sagemaker-ai/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sagemaker-ai",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Build, train, and deploy AI models with deep AWS AI/ML expertise brought directly into your coding assistants, covering the surface area of Amazon SageMaker AI.",
   "author": {
     "name": "Amazon Web Services",

--- a/plugins/sagemaker-ai/skills/model-evaluation/SKILL.md
+++ b/plugins/sagemaker-ai/skills/model-evaluation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: model-evaluation
-description: Generates python code that evaluates SageMaker models. Supports two evaluation types: LLM-as-Judge and Custom Scorer. Use when the user says "evaluate my model", "run a benchmark", "test model performance", "how did my model perform", "compare models", or other similar requests.
+description: 'Generates python code that evaluates SageMaker models. Supports two evaluation types: LLM-as-Judge and Custom Scorer. Use when the user says "evaluate my model", "run a benchmark", "test model performance", "how did my model perform", "compare models", or other similar requests.'
 metadata:
   version: "3.0.0"
 ---


### PR DESCRIPTION
Fixes a YAML frontmatter parse error in the sagemaker-ai plugin's model-evaluation skill.

Related
https://github.com/awslabs/agent-plugins/pull/175

Acknowledgment
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agent-plugins/blob/main/LICENSE).