### PR TITLE
Fix command to install skills for Kiro agent

### DIFF
--- a/plugins/sagemaker-ai/README.md
+++ b/plugins/sagemaker-ai/README.md
@@ -68,7 +68,7 @@ For other agents (Kiro, etc.), install the skills and MCP server manually.
 **Install skills** using the [Skills CLI](https://github.com/vercel-labs/skills). For example, to install for Kiro:
 
 ```
-npx skills add https://github.com/awslabs/agent-plugins/tree/main/plugins/sagemaker-ai/skills --all --agent kiro-cli --copy
+npx skills add https://github.com/awslabs/agent-plugins/tree/main/plugins/sagemaker-ai/skills --skill * --agent kiro-cli --copy
 ```
 
 Replace `kiro-cli` with your agent if different. See [Skills supported agents](https://github.com/vercel-labs/skills#supported-agents).


### PR DESCRIPTION
This pull request updates the installation instructions in the `plugins/sagemaker-ai/README.md` to clarify how to add skills for other agents using the Skills CLI.

#### Related

N/A

#### Changes

Documentation update:

* Changed the Skills CLI command to use `--skill *` instead of `--all` when installing all skills for an agent, providing clearer and more accurate guidance for users.The previous command installed all skills for *all* coding agents, resulting in many irrelevant dot directories being created and populated with skill copies (.claude, .aider-desk, .kode, etc.)

#### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agent-plugins/blob/main/LICENSE).
