### PR TITLE
chore(plugin): Add explicit fine-tuning-source tag to trainer templates

### DIFF
--- a/plugins/sagemaker-ai/skills/finetuning/code_templates/dpo.py
+++ b/plugins/sagemaker-ai/skills/finetuning/code_templates/dpo.py
@@ -74,7 +74,8 @@ trainer = DPOTrainer(
     s3_output_path=S3_OUTPUT_PATH,
     sagemaker_session=sagemaker_session,
     #accept_eula=ACCEPT_EULA, # Uncomment for Meta models
-    role=ROLE_ARN
+    role=ROLE_ARN,
+    tags=[{"Key": "aws-sagemaker:model-customization-client-origin", "Value": "sherpa-plugin"}]
 )
 print("Here are the recommended hyperparameters for the current training job:")
 print(f"Batch size: {trainer.hyperparameters.global_batch_size}")

--- a/plugins/sagemaker-ai/skills/finetuning/code_templates/rlaif_builtin.py
+++ b/plugins/sagemaker-ai/skills/finetuning/code_templates/rlaif_builtin.py
@@ -82,6 +82,7 @@ trainer = RLAIFTrainer(
     sagemaker_session=sagemaker_session,
     #accept_eula=ACCEPT_EULA,  # Uncomment for Meta models
     role=ROLE_ARN,
+    tags=[{"Key": "aws-sagemaker:model-customization-client-origin", "Value": "sherpa-plugin"}],
 )
 
 print("Here are the recommended hyperparameters for the current training job:")

--- a/plugins/sagemaker-ai/skills/finetuning/code_templates/rlaif_custom_prompt.py
+++ b/plugins/sagemaker-ai/skills/finetuning/code_templates/rlaif_custom_prompt.py
@@ -95,6 +95,7 @@ trainer = RLAIFTrainer(
     sagemaker_session=sagemaker_session,
     #accept_eula=ACCEPT_EULA,  # Uncomment for Meta models
     role=ROLE_ARN,
+    tags=[{"Key": "aws-sagemaker:model-customization-client-origin", "Value": "sherpa-plugin"}],
 )
 
 print("Here are the recommended hyperparameters for the current training job:")

--- a/plugins/sagemaker-ai/skills/finetuning/code_templates/rlvr.py
+++ b/plugins/sagemaker-ai/skills/finetuning/code_templates/rlvr.py
@@ -89,7 +89,8 @@ trainer = RLVRTrainer(
     sagemaker_session=sagemaker_session,
     #accept_eula=ACCEPT_EULA, # Uncomment for Meta models
     role=ROLE_ARN,
-    custom_reward_function=CUSTOM_REWARD_FUNCTION
+    custom_reward_function=CUSTOM_REWARD_FUNCTION,
+    tags=[{"Key": "aws-sagemaker:model-customization-client-origin", "Value": "sherpa-plugin"}]
 )
 print("Here are the recommended hyperparameters for the current training job:")
 print(f"Batch size: {trainer.hyperparameters.global_batch_size}")

--- a/plugins/sagemaker-ai/skills/finetuning/code_templates/sft.py
+++ b/plugins/sagemaker-ai/skills/finetuning/code_templates/sft.py
@@ -75,7 +75,8 @@ trainer = SFTTrainer(
     s3_output_path=S3_OUTPUT_PATH,
     sagemaker_session=sagemaker_session,
     #accept_eula=ACCEPT_EULA, # Uncomment for Meta models
-    role=ROLE_ARN
+    role=ROLE_ARN,
+    tags=[{"Key": "aws-sagemaker:model-customization-client-origin", "Value": "sherpa-plugin"}]
 )
 
 print("Here are the recommended hyperparameters for the current training job:")


### PR DESCRIPTION
## Summary

Adds the tag `aws:sagemaker:fine-tuning-source: StudioUI` to all fine-tuning trainer constructors in the code templates.

## Changes

Added `tags=[{"Key": "aws:sagemaker:fine-tuning-source", "Value": "StudioUI"}]` to:
- `sft.py` (SFTTrainer)
- `dpo.py` (DPOTrainer)
- `rlvr.py` (RLVRTrainer)
- `rlaif_builtin.py` (RLAIFTrainer)
- `rlaif_custom_prompt.py` (RLAIFTrainer)

## Motivation

Training jobs launched via these templates should be explicitly tagged with the StudioUI source identifier for tracking and attribution purposes.