### PR TITLE
fix: quote CLAUDE_PLUGIN_ROOT in hook commands to support paths with spaces

### DIFF
--- a/plugins/aws-serverless/hooks/hooks.json
+++ b/plugins/aws-serverless/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/validate-template.sh",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/validate-template.sh\"",
             "timeout": 120
           }
         ]

--- a/plugins/databases-on-aws/scripts/README.md
+++ b/plugins/databases-on-aws/scripts/README.md
@@ -47,7 +47,7 @@ Add additional hooks to `.claude/settings.json` or override the defaults:
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/cluster-info.sh $CLUSTER --region $REGION 2>/dev/null || true"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/cluster-info.sh\" \"$CLUSTER\" --region \"$REGION\" 2>/dev/null || true"
           }
         ]
       }

--- a/plugins/deploy-on-aws/hooks/hooks.json
+++ b/plugins/deploy-on-aws/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/validate-drawio.sh",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/validate-drawio.sh\"",
             "timeout": 30
           }
         ]


### PR DESCRIPTION
## Problem

The \`aws-serverless\` and \`deploy-on-aws\` PostToolUse hooks pass \`\${CLAUDE_PLUGIN_ROOT}\` directly to \`/bin/sh -c\` with no quoting and no explicit interpreter. When \`CLAUDE_CONFIG_DIR\` (and therefore \`CLAUDE_PLUGIN_ROOT\`) contains a space -- e.g. \`/Users/me/Work/Company Name/.claude\` or \`C:\Users\First Last\.claude\plugins\...\` -- the shell word-splits the expanded path and the hook fails on every \`Edit\`/\`Write\`:

\`\`\`
PostToolUse:Edit hook error
Failed with non-blocking status code: /bin/sh: /Users/me/Work/Company: is a directory
\`\`\`

## Fix

Wrap the interpolated path in escaped double quotes and prefix with \`bash\`, matching the pattern used by \`superpowers\` in \`anthropics/claude-plugins-official\`:

\`\`\`diff
-  \"command\": \"\${CLAUDE_PLUGIN_ROOT}/scripts/validate-template.sh\",
+  \"command\": \"bash \\\"\${CLAUDE_PLUGIN_ROOT}/scripts/validate-template.sh\\\"\",
\`\`\`

## Files touched

- \`plugins/aws-serverless/hooks/hooks.json\` -- primary bug from the issue
- \`plugins/deploy-on-aws/hooks/hooks.json\` -- same pattern, same failure mode; fixed for parity
- \`plugins/databases-on-aws/scripts/README.md\` -- doc example that would have taught the broken form; updated so copy-pasters don't hit the same bug

Space-free paths are unaffected (double quotes and \`bash\` are no-ops on well-formed paths).

## Testing

- Verified all three JSON files parse (\`python -c 'import json; json.load(...)'\`).
- Manually confirmed the fixed hook works on a fake plugin under a path with a literal space (\`/tmp/dir with space/scripts/x.sh\` -- resolves without shell error).

Closes #146


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agent-plugins/blob/main/LICENSE).
