### PR TITLE
fix(ci): prevent script injection in merge-prevention workflow

### DIFF
--- a/.github/workflows/merge-prevention.yml
+++ b/.github/workflows/merge-prevention.yml
@@ -45,18 +45,19 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
+      PR_NUMBER_EVENT: ${{ github.event.pull_request.number }}
     steps:
       - name: Get PR info
         id: get-pr
         run: |
-          if [ "${{ github.event_name }}" == "merge_group" ]; then
-            PR_NUMBER=$(echo "${{ github.ref }}" | grep -oP '(?<=/pr-)\d+' || echo "")
-            PR_LABELS=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER | jq -c '[.labels[].name] // []')
+          if [ "$GITHUB_EVENT_NAME" == "merge_group" ]; then
+            PR_NUMBER=$(echo "$GITHUB_REF" | grep -oP '(?<=/pr-)\d+' || echo "")
+            PR_LABELS=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" | jq -c '[.labels[].name] // []')
             echo "::group::Getting Information"
-            gh api repos/${{ github.repository }}/pulls/$PR_NUMBER
+            gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER"
             echo "::endgroup::"
-          elif [ "${{ github.event_name }}" == "pull_request" ]; then
-            PR_NUMBER="${{ github.event.pull_request.number }}"
+          elif [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
+            PR_NUMBER="$PR_NUMBER_EVENT"
             PR_LABELS=$(echo "$PR_LABELS_JSON" | jq -c '.')
           fi
           echo "::group::Debug Output Values"
@@ -70,8 +71,9 @@ jobs:
     needs: get-pr-info
     if: always()
     steps:
-      - run: |
-          PR_NUMBER="${{ needs.get-pr-info.outputs.pr_number }}"
+      - env:
+          PR_NUMBER: ${{ needs.get-pr-info.outputs.pr_number }}
+        run: |
           # Default to 0 (allow all) if not set
           if [ -z "$HALT_MERGES" ]; then
             HALT_MERGES=0
@@ -98,19 +100,21 @@ jobs:
     needs: get-pr-info
     if: always()
     steps:
-      - run: |
+      - env:
+          PR_LABELS: ${{ needs.get-pr-info.outputs.pr_labels }}
+        run: |
           echo "::group::Debug Output Values"
-          echo "PR_LABELS: ${{ needs.get-pr-info.outputs.pr_labels }}"
+          echo "PR_LABELS: $PR_LABELS"
           echo "::endgroup::"
-      - name: When PR has the "${{ env.DO_NOT_MERGE_LABEL }}" label
+      - name: When PR has the do-not-merge label
         id: pr-has-label
         if: contains(needs.get-pr-info.outputs.pr_labels, env.DO_NOT_MERGE_LABEL)
         run: |
-          echo "::error::❌ The label \"${{ env.DO_NOT_MERGE_LABEL }}\" is used to prevent merging."
+          echo "::error::❌ The label \"$DO_NOT_MERGE_LABEL\" is used to prevent merging."
           exit 1
-      - name: When PR does not have the "${{ env.DO_NOT_MERGE_LABEL }}" label
+      - name: When PR does not have the do-not-merge label
         id: pr-missing-label
-        if: ! contains(needs.get-pr-info.outputs.pr_labels, env.DO_NOT_MERGE_LABEL)
+        if: ${{ !contains(needs.get-pr-info.outputs.pr_labels, env.DO_NOT_MERGE_LABEL) }}
         run: |
-          echo "::debug::✅ The label \"${{ env.DO_NOT_MERGE_LABEL }}\" is absent"
+          echo "::debug::✅ The label \"$DO_NOT_MERGE_LABEL\" is absent"
           exit 0


### PR DESCRIPTION
## What

Remediates **script injection (CWE-78)** in `.github/workflows/merge-prevention.yml`. Untrusted GitHub context values were interpolated directly into `run:` shell scripts via `${{ }}`, where Actions substitutes them into the script text *before* the shell executes — so a crafted branch ref or PR label could inject arbitrary commands into the runner.

## Injection points fixed

| Location | Untrusted value | Risk |
| --- | --- | --- |
| `fail-by-label` echo | `pr_labels` output (derived from user-set PR **labels**) | High — most user-controllable |
| `get-pr-info` | `github.ref`, `github.repository`, `github.event.pull_request.number`, `github.event_name` | Medium |
| step `name:` fields | `${{ env.DO_NOT_MERGE_LABEL }}` | Low (hygiene) |

## How

- Use runner **built-in env vars** (`$GITHUB_EVENT_NAME`, `$GITHUB_REF`, `$GITHUB_REPOSITORY`) instead of interpolating `github` context.
- **Bind** PR number and labels to `env:` and reference them as quoted shell variables (`"$VAR"`) so values are treated as data, not code.
- Quote the `gh api` URL argument.
- Use the already-exported `$DO_NOT_MERGE_LABEL` in `run:` scripts and drop the interpolation from step names.
- Wrap the negated condition as `if: ${{ !contains(...) }}` — the original `if: ! contains(...)` was **invalid GitHub Actions expression syntax** (caught by zizmor's schema validation).

## Verification

- **semgrep**: original file triggers `yaml.github-actions.security.run-shell-injection`; fixed file scans clean.
- **zizmor** (v1.26.1, `--offline`): `No findings to report` on the fixed file — including its `template-injection` audit. The original file failed zizmor's schema validation due to the invalid `if:` syntax noted above.
- YAML parses successfully.

## Follow-up

- zizmor is not yet part of CI — tracked in #221.
- Pre-existing gitleaks findings on an unmerged branch are unrelated to this change and handled separately.

Generated with [Claude Code](https://claude.com/claude-code)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agent-plugins/blob/main/LICENSE).