### PR TITLE
fix(ci): scope gitleaks scan to PR commits, not all branches

### DIFF
--- a/.github/workflows/security-scanners.yml
+++ b/.github/workflows/security-scanners.yml
@@ -42,11 +42,24 @@ jobs:
           curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz;
           sudo mv gitleaks /usr/local/bin/;
           gitleaks --version;
-      - name: Run gitleaks (full history)
+      - name: Run gitleaks
         id: gitleaks
+        env:
+          # On pull_request, restrict the scan to commits the PR introduces so
+          # it cannot fail on secrets that live only on other, unmerged branches.
+          # On push/schedule/dispatch, scan the full history reachable from HEAD.
+          PR_BASE_REF: ${{ github.base_ref }}
         run: |
           set +e
-          gitleaks git --config=.gitleaks.toml --baseline-path=.gitleaks-baseline.json --report-path=gitleaks-report_sarif.json --report-format=sarif .
+          # checkout uses fetch-depth: 0, so the base branch is already present
+          # as origin/<base_ref>; no extra fetch is needed.
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            LOG_OPTS="origin/$PR_BASE_REF..HEAD"
+          else
+            LOG_OPTS="HEAD"
+          fi
+          echo "::notice::gitleaks scanning range: $LOG_OPTS"
+          gitleaks git --config=.gitleaks.toml --baseline-path=.gitleaks-baseline.json --log-opts="$LOG_OPTS" --report-path=gitleaks-report_sarif.json --report-format=sarif .
           GITLEAKS_EXIT=$?
           set -e
           echo "exit_code=$GITLEAKS_EXIT" >> "$GITHUB_OUTPUT"

--- a/mise.toml
+++ b/mise.toml
@@ -123,8 +123,11 @@ run = [
 
 [tasks."security:gitleaks"]
 description = "Run GitLeaks"
+# Scan only history reachable from HEAD (the current branch), not every ref in
+# the clone. Without --log-opts, gitleaks walks all refs and fails on secrets
+# that exist only on other, unmerged branches. Matches the CI scan scope.
 run = [
-  "gitleaks git --config=.gitleaks.toml --baseline-path=.gitleaks-baseline.json"
+  "gitleaks git --config=.gitleaks.toml --baseline-path=.gitleaks-baseline.json --log-opts=HEAD",
 ]
 
 [tasks."security:grype"]


### PR DESCRIPTION
Fixes #223

## Problem

The `gitleaks` job in `.github/workflows/security-scanners.yml` runs `gitleaks git ... .` with **no commit range**. In git mode, gitleaks walks the entire object graph reachable from **all refs** in the clone. Because `actions/checkout` uses `fetch-depth: 0`, the runner fetches every branch — so the scan reaches sideways into unrelated branches.

**Consequence:** pull requests fail on secrets that exist only on other, unmerged branches. Concretely, PR #222's gitleaks check is red because of example rule fixtures (`slack-webhook-url`, `private-key`) in `tools/semgrep/r-all.active.yaml` on the unmerged `feat/vendor-semgrep-rules` branch (PR #220) — a file that isn't in `main` or in PR #222 at all. The CI log shows `169 commits scanned` (far more than the PR's own commits) → `leaks found: 3`.

The local `mise run build` (`security:gitleaks` task) had the identical broad-scope problem and failed the same way.

## Fix

**CI** (`security-scanners.yml`) — scope the scan by event type:

| Event | Range | Rationale |
| --- | --- | --- |
| `pull_request` | `origin/<base_ref>..HEAD` | Only the commits the PR introduces — cannot fail on another branch's content |
| `push` / `schedule` / `workflow_dispatch` | `HEAD` | Full history reachable from HEAD — preserves complete coverage of `main` |

**Local** (`mise.toml` `security:gitleaks` task) — add `--log-opts=HEAD` so the local scan matches CI scope (current-branch history only, not sideways branches).

`github.base_ref` is bound to an `env:` var and referenced as `"$PR_BASE_REF"` (never interpolated into the shell) to avoid the script-injection class being addressed in #222.

## Verification

- YAML parses.
- **Local `mise run security:gitleaks` now passes**: 119 commits scanned (HEAD ancestry) vs. 221 (all refs) → `no leaks found`.
- Scoped scans confirm isolation: `origin/main` history → 0 leaks; all-refs default → 3 leaks (the other branch's fixtures).
- `checkout` already fetches full history (`fetch-depth: 0`), so `origin/<base_ref>` is present without an extra fetch.

## Notes / follow-ups

- Draft until reviewed — narrowing scan scope is a deliberate security trade-off. Full-history coverage of `main` is retained via the push/schedule branch of the conditional (CI) and remains available locally on `main`.
- The example secrets themselves should be allowlisted/baselined on PR #220 (they are Semgrep rule fixtures, not live credentials).
- Related: zizmor CI integration (#221), workflow script-injection fix (#222).

Generated with [Claude Code](https://claude.com/claude-code)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agent-plugins/blob/main/LICENSE).