### PR TITLE
docs: document fast-forward-only rule for main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,7 +174,7 @@ claude --plugin-dir ./plugins/deploy-on-aws
 
 ## Git Worktree Workflow
 
-ALWAYS use git worktrees for new work. The main worktree stays on its current branch and is never switched. Each piece of work gets its own worktree under `.tmp/`, branching off the current branch. This enables multiple agents to work in parallel without conflicts.
+ALWAYS use git worktrees for new work. The main worktree stays on its current branch and is never switched. Each piece of work gets its own worktree under `.tmp/`, branching off the latest `origin/main`. This enables multiple agents to work in parallel without conflicts.
 
 ```bash
 # Fast-forward main first, then branch new work off the latest remote

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,8 +177,9 @@ claude --plugin-dir ./plugins/deploy-on-aws
 ALWAYS use git worktrees for new work. The main worktree stays on its current branch and is never switched. Each piece of work gets its own worktree under `.tmp/`, branching off the current branch. This enables multiple agents to work in parallel without conflicts.
 
 ```bash
-# Create a worktree for new work (branches off current branch)
-git worktree add .tmp/<short-name> -b <branch-name>
+# Fast-forward main first, then branch new work off the latest remote
+git pull --ff-only origin main
+git worktree add .tmp/<short-name> -b <branch-name> origin/main
 
 # Create a worktree for an existing branch
 git worktree add .tmp/<short-name> <branch-name>
@@ -195,6 +196,7 @@ All worktrees live under `.tmp/` (already in `.gitignore`).
 ## Boundaries
 
 - ALWAYS use `git worktree add .tmp/<name>` for new work. NEVER switch branches in the main worktree.
+- ONLY fast-forward `main` (`git pull --ff-only`); never commit, merge, or rebase it locally.
 - ALWAYS Use mise commands to interact with the codebase. If a command is not available, add it.
 - NEVER add new dependencies without asking first.
 - ALWAYS run a full build when done with a task, this is to ensure all required files are generated before commit.


### PR DESCRIPTION
## What

Codifies the "only fast-forward `main`" rule in `AGENTS.md` (and via symlink, `CLAUDE.md`), so new worktrees and branches always start from the latest remote state.

## Changes (4 lines)

- **Worktree snippet**: fast-forward `main` (`git pull --ff-only origin main`) and branch new work off `origin/main`.
- **Boundary**: `ONLY fast-forward main (git pull --ff-only); never commit, merge, or rebase it locally.`

Kept intentionally terse — modern agents already understand fast-forward semantics; this just states the project's expectation.

## Verification

- `mise run lint:md` → 0 errors.
- Edited `AGENTS.md` only; `CLAUDE.md` inherits via symlink.

Generated with [Claude Code](https://claude.com/claude-code)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agent-plugins/blob/main/LICENSE).