### PR TITLE
docs(dsql): add StartTransaction wait event to Workflow 12 diagnostics

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,7 +27,12 @@
       ],
       "name": "amazon-location-service",
       "source": "./plugins/amazon-location-service",
-      "tags": ["aws", "location", "maps", "geospatial"],
+      "tags": [
+        "aws",
+        "location",
+        "maps",
+        "geospatial"
+      ],
       "version": "1.0.0"
     },
     {
@@ -45,7 +50,11 @@
       ],
       "name": "aws-amplify",
       "source": "./plugins/aws-amplify",
-      "tags": ["aws", "amplify", "fullstack"],
+      "tags": [
+        "aws",
+        "amplify",
+        "fullstack"
+      ],
       "version": "1.0.0"
     },
     {
@@ -117,7 +126,13 @@
       ],
       "name": "aws-transform",
       "source": "./plugins/aws-transform",
-      "tags": ["aws", "migration", "modernization", "transform", "continuous modernization"],
+      "tags": [
+        "aws",
+        "migration",
+        "modernization",
+        "transform",
+        "continuous modernization"
+      ],
       "version": "1.3.0"
     },
     {
@@ -138,7 +153,12 @@
       ],
       "name": "codebase-documentor-for-aws",
       "source": "./plugins/codebase-documentor-for-aws",
-      "tags": ["aws", "documentation", "architecture", "diagram"],
+      "tags": [
+        "aws",
+        "documentation",
+        "architecture",
+        "diagram"
+      ],
       "version": "0.1.0"
     },
     {
@@ -163,8 +183,15 @@
       ],
       "name": "databases-on-aws",
       "source": "./plugins/databases-on-aws",
-      "tags": ["aws", "database", "aurora", "dsql", "serverless", "postgresql"],
-      "version": "1.6.0"
+      "tags": [
+        "aws",
+        "database",
+        "aurora",
+        "dsql",
+        "serverless",
+        "postgresql"
+      ],
+      "version": "1.6.1"
     },
     {
       "category": "deployment",
@@ -184,7 +211,13 @@
       ],
       "name": "deploy-on-aws",
       "source": "./plugins/deploy-on-aws",
-      "tags": ["aws", "deploy", "infrastructure", "cdk", "diagrams"],
+      "tags": [
+        "aws",
+        "deploy",
+        "infrastructure",
+        "cdk",
+        "diagrams"
+      ],
       "version": "1.3.0"
     },
     {
@@ -203,7 +236,12 @@
       ],
       "name": "sagemaker-ai",
       "source": "./plugins/sagemaker-ai",
-      "tags": ["aws", "sagemaker", "machine-learning", "generative-ai"],
+      "tags": [
+        "aws",
+        "sagemaker",
+        "machine-learning",
+        "generative-ai"
+      ],
       "version": "1.2.1"
     }
   ]

--- a/plugins/databases-on-aws/.claude-plugin/plugin.json
+++ b/plugins/databases-on-aws/.claude-plugin/plugin.json
@@ -22,5 +22,5 @@
   "license": "Apache-2.0",
   "name": "databases-on-aws",
   "repository": "https://github.com/awslabs/agent-plugins",
-  "version": "1.6.0"
+  "version": "1.6.1"
 }

--- a/plugins/databases-on-aws/.codex-plugin/plugin.json
+++ b/plugins/databases-on-aws/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "databases-on-aws",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Expert database guidance for the AWS database portfolio. Design schemas, execute queries, handle migrations, and choose the right database for your workload.",
   "author": {
     "name": "Amazon Web Services",

--- a/plugins/databases-on-aws/skills/dsql/references/system-diagnostics/wait-events.md
+++ b/plugins/databases-on-aws/skills/dsql/references/system-diagnostics/wait-events.md
@@ -199,13 +199,18 @@ Commit process has begun, and QP is waiting for a response.
 
 Waiting for distributed transaction start — the time a session spends while DSQL coordinates the operations needed to begin a new transaction.
 
-This is internal DSQL infrastructure overhead; there are no user-tunable parameters that affect it. Its value in diagnostics is purely **proportional** — a growing share of StartTransaction vs baselines indicates a shift in workload pattern toward more frequent short transactions (each paying the fixed start cost), but no user action can reduce the per-transaction cost itself.
+**Possible causes** (candidates to confirm — see the observe-only guardrail above):
+
+- High transaction frequency (many short transactions, each paying the fixed start cost)
+- Workload shift toward more fine-grained transactions vs fewer large ones
+
+This is internal DSQL infrastructure overhead; there are no user-tunable parameters that affect the per-transaction start cost itself. Its value in diagnostics is purely **proportional** — a growing share indicates a shift in workload pattern.
 
 **Observe-only steps:**
 
-1. Note whether StartTransaction's share of total AAS has changed vs the temporal baseline
-2. If the share grew significantly (>30% shift), it likely reflects an increase in transaction frequency — correlate with the `TotalTransactions` CW metric to confirm
-3. Report the observation. There is no remediation for this event — it is fixed internal overhead per transaction start.
+1. Note whether StartTransaction's proportion of total AAS has changed by >30% vs the temporal baseline: `sum by ("db.wait.event")({__name__="db.active_sessions.avg", "db.wait.event"="StartTransaction", ...})`
+2. If the proportion grew significantly, it likely reflects an increase in transaction frequency — correlate with the `TotalTransactions` CW metric (namespace `AWS/AuroraDSQL`, `statistic="Sum"` — it is a cumulative counter) to confirm
+3. Report the observation — do not recommend transaction batching, connection pooling changes, or other remediations from CloudWatch data alone. This is fixed internal overhead with no user-facing tuning knob.
 
 ---
 

--- a/plugins/databases-on-aws/skills/dsql/references/system-diagnostics/wait-events.md
+++ b/plugins/databases-on-aws/skills/dsql/references/system-diagnostics/wait-events.md
@@ -21,6 +21,7 @@ Aurora DSQL exposes wait events via the `db.wait.event` label on `db.active_sess
 | FkExistenceCheck      | Validation  | Storage reads to validate foreign key existence                                                            |
 | UniqueConstraintCheck | Validation  | Storage reads to validate unique key constraints for non-primary columns                                   |
 | Commit                | Transaction | Commit process has begun, and QP is waiting for a response                                                 |
+| StartTransaction      | Transaction | Waiting for distributed transaction start                                                                  |
 | PgSleep               | Application | Session issued `pg_sleep()` and is waiting for the sleep period to complete                                |
 
 ---
@@ -191,6 +192,20 @@ Commit process has begun, and QP is waiting for a response.
    - If OccConflicts grows faster than TotalTransactions → conflict-dominated (report this observation)
    - If TotalTransactions grows proportionally to Commit AAS → legitimate load growth (report this observation)
 3. If OCC conflicts are the growing component, hand off to Workflow 9 for transaction-pattern analysis and conflict mitigation — do not prescribe schema or transaction changes from CloudWatch data alone
+
+---
+
+## StartTransaction
+
+Waiting for distributed transaction start — the time a session spends while DSQL coordinates the operations needed to begin a new transaction.
+
+This is internal DSQL infrastructure overhead; there are no user-tunable parameters that affect it. Its value in diagnostics is purely **proportional** — a growing share of StartTransaction vs baselines indicates a shift in workload pattern toward more frequent short transactions (each paying the fixed start cost), but no user action can reduce the per-transaction cost itself.
+
+**Observe-only steps:**
+
+1. Note whether StartTransaction's share of total AAS has changed vs the temporal baseline
+2. If the share grew significantly (>30% shift), it likely reflects an increase in transaction frequency — correlate with the `TotalTransactions` CW metric to confirm
+3. Report the observation. There is no remediation for this event — it is fixed internal overhead per transaction start.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds the new `StartTransaction` wait event to the Workflow 12 system diagnostics reference (`wait-events.md`)
- Category: Transaction. Description: "Waiting for distributed transaction start"
- Added to the summary table and as its own section following the observe-only doctrine

## Details

`StartTransaction` represents the time a session spends waiting for the internal operations DSQL performs to begin a new transaction. This is fixed infrastructure overhead — there are no user-tunable parameters that affect it. Its value in diagnostics is purely proportional: a growing share vs baselines indicates a shift toward more frequent short transactions, each paying the fixed start cost.

The section follows the same observe-only framing as the other wait events: observe the proportion, correlate with `TotalTransactions` if the share grew, report the observation. No remediation is prescribed.

## Test plan

- [ ] `mise run build` passes (verified locally)
- [ ] wait-events.md summary table includes StartTransaction in the correct position
- [ ] New section follows the observe-only doctrine (no prescriptive fixes)

Generated with [Claude Code](https://claude.com/claude-code)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agent-plugins/blob/main/LICENSE).