### PR TITLE
fix: resolve ruff-check lint errors in non-template Python files

### DIFF
--- a/plugins/aws-transform/skills/aws-transform/scripts/verify-traceability.py
+++ b/plugins/aws-transform/skills/aws-transform/scripts/verify-traceability.py
@@ -361,9 +361,6 @@ def generate_html(result: dict) -> str:
 
     rules_pct = _pct(s["implemented_rules"], s["total_rules"])
     reqs_pct = _pct(s["implemented_requirements"], s["total_requirements"])
-    overall_total = s["total_rules"] + s["total_requirements"]
-    overall_impl = s["implemented_rules"] + s["implemented_requirements"]
-    overall_pct = _pct(overall_impl, overall_total)
 
     # Build per-function rows for summary table
     func_rows = ""
@@ -666,7 +663,7 @@ def main():
     # Print summary to stdout
     s = result["summary"]
     print(f"\n{'='*60}")
-    print(f"TRACEABILITY VERIFICATION SUMMARY")
+    print("TRACEABILITY VERIFICATION SUMMARY")
     print(f"{'='*60}")
     print(f"Business Rules (captured):           "
           f"{s['implemented_rules']}/{s['total_rules']} "
@@ -675,7 +672,7 @@ def main():
           f"{s['implemented_requirements']}/{s['total_requirements']} "
           f"({_pct(s['implemented_requirements'], s['total_requirements'])})")
     print(f"{'─'*60}")
-    print(f"Scope: Chapters 1–8 of specification files only")
+    print("Scope: Chapters 1–8 of specification files only")
     print(f"{'='*60}")
 
     missing_rules = s["missing_rules"]
@@ -688,8 +685,8 @@ def main():
             print(f"\n⚠  {missing_reqs} REQ-* identifiers NOT found in chapters "
                   f"1–8 of any specification file.")
     else:
-        print(f"\n✅ All business rules and REQ-* identifiers found in "
-              f"chapters 1–8 of specification files.")
+        print("\n✅ All business rules and REQ-* identifiers found in "
+              "chapters 1–8 of specification files.")
 
     # Write HTML dashboard
     dashboard_html = generate_html(result)

--- a/plugins/deploy-on-aws/scripts/lib/post_process_drawio.py
+++ b/plugins/deploy-on-aws/scripts/lib/post_process_drawio.py
@@ -199,7 +199,6 @@ def fix_placement(tree: ET.ElementTree, verbose: bool = False) -> int:
             cloud_x = aws_cloud_geom["x"]
             cloud_x2 = cloud_x + aws_cloud_geom["w"]
             actor_x = g["x"]
-            actor_x2 = actor_x + g["w"]
 
             # Check if actor overlaps AWS Cloud horizontally
             if actor_x >= cloud_x and actor_x < cloud_x2:

--- a/plugins/sagemaker-ai/skills/dataset-evaluation/scripts/format_detector.py
+++ b/plugins/sagemaker-ai/skills/dataset-evaluation/scripts/format_detector.py
@@ -538,7 +538,7 @@ def _validate_samples(samples: list[dict], expected_format: FormatType, line_num
                     errors.append(ValidationError(
                         line_number=line_num,
                         error_type="invalid_structure",
-                        message=f"Field 'messages' must be a list"
+                        message="Field 'messages' must be a list"
                     ))
                     skip_messages = True
                 elif prefix:

--- a/plugins/sagemaker-ai/skills/finetuning/templates/nova_rlvr_reward_function_source_template.py
+++ b/plugins/sagemaker-ai/skills/finetuning/templates/nova_rlvr_reward_function_source_template.py
@@ -6,6 +6,10 @@ at: https://docs.aws.amazon.com/sagemaker/latest/dg/customize-model.html.
 - Do not remove the lambda_handler() function or modify its schema as it is required to create the reward function
 """
 
+# Starter template: the imports and example variables below are intentional
+# scaffolding for the reader to build on, so unused-name rules do not apply.
+# ruff: noqa: F401, F841
+
 import json  # For JSON parsing - adjust imports based on your use case
 import re    # For pattern matching and validation
 from typing import Dict, Any, List, Optional, Union # For type hints

--- a/plugins/sagemaker-ai/skills/finetuning/templates/rlvr_reward_function_source_template.py
+++ b/plugins/sagemaker-ai/skills/finetuning/templates/rlvr_reward_function_source_template.py
@@ -6,6 +6,10 @@ at: https://docs.aws.amazon.com/sagemaker/latest/dg/customize-model.html.
 - Do not remove the lambda_handler() function or modify its schema as it is required to create the reward function
 """
 
+# Starter template: the imports and example variables below are intentional
+# scaffolding for the reader to build on, so unused-name rules do not apply.
+# ruff: noqa: F401, F841
+
 import json  # For JSON parsing - adjust imports based on your use case
 import re    # For pattern matching and validation
 from typing import Dict, Any, List, Optional # For type hints

--- a/plugins/sagemaker-ai/skills/hyperpod-issue-report/scripts/hyperpod_issue_report.py
+++ b/plugins/sagemaker-ai/skills/hyperpod-issue-report/scripts/hyperpod_issue_report.py
@@ -164,7 +164,7 @@ class HyperPodIssueReportCollector:
             
             if 'Eks' in orchestrator:
                 self.cluster_type = 'eks'
-                print(f"Detected cluster type: EKS")
+                print("Detected cluster type: EKS")
                 # Extract EKS cluster ARN
                 eks_config = orchestrator.get('Eks', {})
                 self.eks_cluster_arn = eks_config.get('ClusterArn')
@@ -177,11 +177,11 @@ class HyperPodIssueReportCollector:
                     print("Warning: Could not extract EKS cluster ARN from orchestrator config")
             elif 'Slurm' in orchestrator:
                 self.cluster_type = 'slurm'
-                print(f"Detected cluster type: Slurm")
+                print("Detected cluster type: Slurm")
             else:
                 # If Orchestrator field is missing or doesn't contain Eks/Slurm, assume Slurm
                 self.cluster_type = 'slurm'
-                print(f"Orchestrator field not found or unrecognized, assuming cluster type: Slurm")
+                print("Orchestrator field not found or unrecognized, assuming cluster type: Slurm")
             
             self.cluster_arn = response.get('ClusterArn')
             self.cluster_id = self.extract_cluster_id_from_arn(self.cluster_arn)
@@ -265,7 +265,7 @@ class HyperPodIssueReportCollector:
         # Resolve EKS node names if present
         if eks_node_names:
             if self.cluster_type == 'eks':
-                print(f"Resolving EKS node names to instance IDs...")
+                print("Resolving EKS node names to instance IDs...")
                 for eks_name in eks_node_names:
                     # Extract instance ID from hyperpod-i-* format
                     # Format: hyperpod-i-0123456789abcdef0
@@ -280,13 +280,13 @@ class HyperPodIssueReportCollector:
                         print(f"  Warning: Invalid EKS node name format '{eks_name}'")
             else:
                 print(f"Warning: EKS node names provided but cluster type is {self.cluster_type}")
-                print(f"  EKS node names (hyperpod-i-*) are only supported for EKS clusters")
+                print("  EKS node names (hyperpod-i-*) are only supported for EKS clusters")
                 print(f"  Ignoring: {', '.join(eks_node_names)}")
         
         # Resolve Slurm node names if present
         if slurm_node_names:
             if self.cluster_type == 'slurm':
-                print(f"Resolving Slurm node names to instance IDs...")
+                print("Resolving Slurm node names to instance IDs...")
                 
                 # Build a mapping of Slurm node name to instance ID
                 slurm_to_instance = {}
@@ -308,7 +308,7 @@ class HyperPodIssueReportCollector:
                         print(f"  Warning: Slurm node name '{slurm_name}' not found in cluster")
             else:
                 print(f"Warning: Slurm node names provided but cluster type is {self.cluster_type}")
-                print(f"  Slurm node names (ip-*) are only supported for Slurm clusters")
+                print("  Slurm node names (ip-*) are only supported for Slurm clusters")
                 print(f"  Ignoring: {', '.join(slurm_node_names)}")
         
         return instance_ids
@@ -592,19 +592,19 @@ class HyperPodIssueReportCollector:
                         output_sample = output_sample[-1000:]  # Last 1000 chars
                 
                 error_msg = (
-                    f"Failed to detect shell prompt after 60 seconds.\n"
-                    f"This may indicate:\n"
-                    f"  - Custom SSM session configuration interfering with prompt detection\n"
-                    f"  - Non-standard shell prompt format\n"
-                    f"  - SSM session initialization issues\n"
+                    "Failed to detect shell prompt after 60 seconds.\n"
+                    "This may indicate:\n"
+                    "  - Custom SSM session configuration interfering with prompt detection\n"
+                    "  - Non-standard shell prompt format\n"
+                    "  - SSM session initialization issues\n"
                 )
                 
                 if output_sample:
                     error_msg += f"\nSession output received:\n{output_sample}\n"
                     error_msg += (
-                        f"\nExpected prompt patterns: $ or # followed by space\n"
-                        f"If your cluster uses custom SSM session commands or non-standard prompts,\n"
-                        f"this tool may not be compatible."
+                        "\nExpected prompt patterns: $ or # followed by space\n"
+                        "If your cluster uses custom SSM session commands or non-standard prompts,\n"
+                        "this tool may not be compatible."
                     )
                 else:
                     error_msg += "\nNo output received from SSM session."
@@ -712,11 +712,11 @@ class HyperPodIssueReportCollector:
                     output_sample = output_sample[-1000:]  # Last 1000 chars
             
             error_msg = (
-                f"Operation timed out during command execution.\n"
-                f"This may indicate:\n"
-                f"  - Command taking longer than expected to complete\n"
-                f"  - Custom shell configuration interfering with output detection\n"
-                f"  - Network or SSM session issues\n"
+                "Operation timed out during command execution.\n"
+                "This may indicate:\n"
+                "  - Command taking longer than expected to complete\n"
+                "  - Custom shell configuration interfering with output detection\n"
+                "  - Network or SSM session issues\n"
             )
             
             if output_sample:
@@ -844,9 +844,9 @@ class HyperPodIssueReportCollector:
         
         # Show what will be collected based on cluster type
         if self.cluster_type == 'eks':
-            print(f"Default collections: nvidia-smi, containerd status, kubelet status, EKS log collector, resource config, cluster logs, systemd services, disk usage")
+            print("Default collections: nvidia-smi, containerd status, kubelet status, EKS log collector, resource config, cluster logs, systemd services, disk usage")
         elif self.cluster_type == 'slurm':
-            print(f"Default collections: nvidia-smi, nvidia-bug-report, sinfo, Slurm services, Slurm config, Slurm logs, system logs")
+            print("Default collections: nvidia-smi, nvidia-bug-report, sinfo, Slurm services, Slurm config, Slurm logs, system logs")
         
         if commands:
             print(f"Additional commands: {', '.join(commands)}")
@@ -909,7 +909,7 @@ class HyperPodIssueReportCollector:
         summary_saved = self.save_summary(results)
 
         print("-" * 60)
-        print(f"\nReport collection completed!")
+        print("\nReport collection completed!")
         print(f"Instance reports uploaded to: s3://{self.s3_bucket}/{self.report_s3_key}/instances/")
         if summary_saved:
             print(f"Summary: s3://{self.s3_bucket}/{self.report_s3_key}/summary.json")
@@ -919,7 +919,7 @@ class HyperPodIssueReportCollector:
         # Print statistics
         successful = sum(1 for r in results if r['Success'])
         failed = len(results) - successful
-        print(f"\nStatistics:")
+        print("\nStatistics:")
         print(f"  Total nodes: {len(results)}")
         print(f"  Successful: {successful}")
         print(f"  Failed: {failed}")
@@ -1013,7 +1013,7 @@ class HyperPodIssueReportCollector:
                     print(f"  Failed to download {relative_path}: {e}")
                     failed += 1
             
-            print(f"\n✓ Download completed!")
+            print("\n✓ Download completed!")
             print(f"  Downloaded: {downloaded} files")
             if failed > 0:
                 print(f"  Failed: {failed} files")
@@ -1057,7 +1057,7 @@ class HyperPodIssueReportCollector:
             zip_size = os.path.getsize(zip_filename)
             zip_size_mb = zip_size / (1024 * 1024)
             
-            print(f"\n✓ Zip archive created!")
+            print("\n✓ Zip archive created!")
             print(f"  File: {zip_filename}")
             print(f"  Size: {zip_size_mb:.2f} MB")
             print(f"  Files: {file_count}")
@@ -1144,7 +1144,7 @@ class HyperPodIssueReportCollector:
                     region = arn_parts[3]
                     
                     print("\n" + "!" * 60)
-                    print(f"ERROR: kubectl context does not match EKS cluster")
+                    print("ERROR: kubectl context does not match EKS cluster")
                     print(f"Current context: {current_context}")
                     print(f"Expected cluster: {self.eks_cluster_name}")
                     print("!" * 60)
@@ -1362,7 +1362,7 @@ class HyperPodIssueReportCollector:
             
             self.s3_client.upload_file(tarball_path, self.s3_bucket, s3_key)
             
-            print(f"✓ Successfully uploaded kubectl resource information to S3")
+            print("✓ Successfully uploaded kubectl resource information to S3")
             print(f"  Location: s3://{self.s3_bucket}/{s3_key}")
 
         except Exception as e:

--- a/plugins/sagemaker-ai/skills/model-evaluation/scripts/reward_function_source_template.py
+++ b/plugins/sagemaker-ai/skills/model-evaluation/scripts/reward_function_source_template.py
@@ -6,6 +6,10 @@ at: https://docs.aws.amazon.com/sagemaker/latest/dg/customize-model.html.
 - Do not remove the lambda_handler() function or modify its schema as it is required to create the reward function
 """
 
+# Starter template: the imports and example variables below are intentional
+# scaffolding for the reader to build on, so unused-name rules do not apply.
+# ruff: noqa: F401, F841
+
 import json  # For JSON parsing - adjust imports based on your use case
 import re    # For pattern matching and validation
 from typing import Dict, Any, List, Optional # For type hints

--- a/plugins/sagemaker-ai/skills/model-evaluation/scripts/validate_custom_metrics.py
+++ b/plugins/sagemaker-ai/skills/model-evaluation/scripts/validate_custom_metrics.py
@@ -7,7 +7,7 @@ Usage:
 
 import json
 import sys
-from typing import Optional, Union
+from typing import Optional
 
 from pydantic import BaseModel, field_validator, model_validator
 

--- a/tools/evals/databases-on-aws/dsql/scripts/run_functional_evals.py
+++ b/tools/evals/databases-on-aws/dsql/scripts/run_functional_evals.py
@@ -279,7 +279,7 @@ def grade_eval(eval_item: dict, run_result: dict, judge_model: str | None = None
                 if re.search(r"(awsknowledge|aws___search_documentation)", full_text):
                     if not topic or topic in full_text:
                         passed = True
-                        evidence = f"Found awsknowledge reference in transcript text"
+                        evidence = "Found awsknowledge reference in transcript text"
 
             if not passed:
                 evidence = f"No awsknowledge call found{' for topic: ' + topic if topic else ''}"

--- a/tools/evals/databases-on-aws/dsql/scripts/test_safe_query.py
+++ b/tools/evals/databases-on-aws/dsql/scripts/test_safe_query.py
@@ -44,7 +44,6 @@ except ImportError:
     pytest = _PytestShim()
 
 from safe_query import (  # noqa: E402
-    INT,
     TENANT_SLUG,
     UUID,
     Safe,

--- a/tools/init-skill.py
+++ b/tools/init-skill.py
@@ -120,7 +120,7 @@ def main() -> int:
     print("Next steps:")
     print(f"  1. Edit {rel_path}/SKILL.md — fill in the [FILL] sections")
     print(f"  2. Add reference files to {rel_path}/references/")
-    print(f"  3. Run: mise run validate")
+    print("  3. Run: mise run validate")
 
     return 0
 

--- a/tools/validate-urls.py
+++ b/tools/validate-urls.py
@@ -19,7 +19,11 @@ import os
 import re
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 from urllib.parse import urldefrag
+
+if TYPE_CHECKING:
+    import httpx
 
 ROOT = Path(__file__).resolve().parent.parent
 IGNORE_FILE = ROOT / ".url-check-ignore"


### PR DESCRIPTION
Fixes #218

## Scope

`ruff check` (v0.15.0, the pinned pre-commit rev) reports **91** findings on `main`. They split cleanly in two:

| | findings | files | |
| --- | --- | --- | --- |
| `code_templates/*.py` | 46 (44 `invalid-syntax`, 2 `E402`) | 12 | **#214** — untouched here |
| everything else | **45** (`F541` 35, `F841` 5, `F401` 4, `F821` 1) | 12 | **this PR** |

Non-template findings are now **0**. The 46 belonging to #214 are unchanged.

Two notes on how this differs from the issue description, which was written on 2026-07-06:

- The affected non-template file list has grown from 4 to 12 as the repo has gained scripts.
- `E402` is no longer among the non-template codes — both remaining `E402` findings are inside `code_templates/`, so they belong to #214. The non-template codes are now `F541`, `F841`, `F401` and `F821`.

## Mechanical fixes

Applied with `ruff check --fix` (safe fixes only; no `--unsafe-fixes`):

- **`F541` (35)** — dropped the `f` prefix from f-strings with no placeholders.
- **`F401` (2 of 4)** — removed `typing.Union` from `validate_custom_metrics.py` and `INT` from `test_safe_query.py`. I checked that `INT` is not reachable through that file's `globals()`-based fallback test discovery, which selects only callables named `test_*`; `INT_INJECTIONS` is a separate name and is still used.

## Reviewed individually

**`tools/validate-urls.py` — `F821` undefined name `httpx`**
This is a PEP 723 inline script that imports `httpx` lazily inside `check_url` and `main`, so the module-scope annotation `client: "httpx.AsyncClient"` had nothing to resolve against. Added a `TYPE_CHECKING`-guarded import rather than a `noqa`, which keeps the lazy-import behaviour intact — I verified the module still imports with `httpx` absent, and the annotation is preserved.

**`verify-traceability.py` — `F841` `overall_pct`**
`generate_html` computed `overall_total`, `overall_impl` and `overall_pct`, but only `rules_pct` and `reqs_pct` are ever rendered. Removing just `overall_pct` would have left the other two unused, so all three go. This looks like an intended "overall" dashboard stat that was never wired into the HTML — worth a follow-up if you want that row displayed rather than deleted.

**`post_process_drawio.py` — `F841` `actor_x2`**
Removed. Flagging what it hints at, since it may be worth its own issue: the overlap test on the next line is

```python
if actor_x >= cloud_x and actor_x < cloud_x2:
```

which only detects an actor whose **left edge** is inside the AWS Cloud. An actor starting left of the cloud and extending into it is not detected. `actor_x2` is exactly the term a full interval-overlap test would need, so this reads like an unfinished check. I have not changed that behaviour here — it is a layout change, not a lint fix, and should be your call.

## Templates

The three `*_source_template.py` files are customer-facing starter templates (`"INITIAL SUGGESTION ONLY - MUST BE CUSTOMIZED"`), where `from typing import Dict, Any, List, Optional # For type hints` and the example variables are deliberate scaffolding for the reader. Stripping them would remove the thing the template exists to provide, so each gets a file-level directive instead, as the issue suggests:

```python
# Starter template: the imports and example variables below are intentional
# scaffolding for the reader to build on, so unused-name rules do not apply.
# ruff: noqa: F401, F841
```

## Verification

- `ruff check .` → non-template findings 0; remaining 46 are all `code_templates/*` (#214).
- All 12 changed files parse (`ast.parse`) and byte-compile.
- `tools/evals/databases-on-aws/dsql/scripts/test_safe_query.py` → **63 passed, 0 failed**.
- `validate-urls.py` imports at module scope with `httpx` not installed.
- `verify-traceability.py` and `post_process_drawio.py` behave identically to `main` on import (the latter raises the same pre-existing `defusedxml` `AttributeError` in my environment both before and after).

**Out of scope:** `ruff-format` fails repo-wide on `main` — 25 files, including files this PR touches. That count is **25 before and 25 after**, so nothing here adds to it. Running the formatter would turn this into an unrelated 25-file diff, so I left it alone; happy to file it separately if it is not already tracked under #213.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agent-plugins/blob/main/LICENSE).
