### PR TITLE
refactor(sagemaker-ai): remove --command option from hyperpod-issue-report

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -242,7 +242,7 @@
         "machine-learning",
         "generative-ai"
       ],
-      "version": "1.2.1"
+      "version": "1.3.0"
     }
   ]
 }

--- a/plugins/sagemaker-ai/.claude-plugin/plugin.json
+++ b/plugins/sagemaker-ai/.claude-plugin/plugin.json
@@ -18,5 +18,5 @@
   "license": "Apache-2.0",
   "name": "sagemaker-ai",
   "repository": "https://github.com/awslabs/agent-plugins",
-  "version": "1.2.1"
+  "version": "1.3.0"
 }

--- a/plugins/sagemaker-ai/.codex-plugin/plugin.json
+++ b/plugins/sagemaker-ai/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sagemaker-ai",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Build, train, and deploy AI models with deep AWS AI/ML expertise brought directly into your coding assistants, covering the surface area of Amazon SageMaker AI.",
   "author": {
     "name": "Amazon Web Services",

--- a/plugins/sagemaker-ai/skills/hyperpod-issue-report/SKILL.md
+++ b/plugins/sagemaker-ai/skills/hyperpod-issue-report/SKILL.md
@@ -27,7 +27,6 @@ Collect from the user:
 - **S3 path** for report storage (required, e.g. `s3://bucket/prefix`). If the user doesn't have a bucket, create one (e.g., `s3://hyperpod-diagnostics-<account-id>-<region>`)
 - **Issue description** (optional)
 - **Target scope**: all nodes, specific instance groups, or specific node IDs (optional)
-- **Additional commands** to run on nodes (optional)
 
 ### 2. Verify Environment
 
@@ -60,7 +59,7 @@ uv run scripts/hyperpod_issue_report.py \
   --s3-path s3://<bucket>[/prefix]
 ```
 
-Use `--help` for all options including `--instance-groups`, `--nodes`, `--command`, `--max-workers`, and `--debug`. Note: `--instance-groups` and `--nodes` are mutually exclusive. Node identifiers accept instance IDs (`i-*`), EKS names (`hyperpod-i-*`), or Slurm names (`ip-*`).
+Use `--help` for all options including `--instance-groups`, `--nodes`, `--max-workers`, and `--debug`. Note: `--instance-groups` and `--nodes` are mutually exclusive. Node identifiers accept instance IDs (`i-*`), EKS names (`hyperpod-i-*`), or Slurm names (`ip-*`).
 
 ### 4. Present Results
 

--- a/plugins/sagemaker-ai/skills/hyperpod-issue-report/references/collection-details.md
+++ b/plugins/sagemaker-ai/skills/hyperpod-issue-report/references/collection-details.md
@@ -63,10 +63,6 @@ Packaged as `kubectl_resources.tar.gz`, collected from the local machine (not fr
 - `dmesg_T.txt` — Kernel ring buffer with timestamps
 - `var_log_slurm/` — Slurm logs from `/var/log/slurm/`
 
-### Custom Commands
-
-User-specified commands are saved as `command_01_<sanitized_name>.txt`, `command_02_...`, etc.
-
 ## Report Output Structure
 
 ```

--- a/plugins/sagemaker-ai/skills/hyperpod-issue-report/scripts/hyperpod_issue_report.py
+++ b/plugins/sagemaker-ai/skills/hyperpod-issue-report/scripts/hyperpod_issue_report.py
@@ -313,7 +313,7 @@ class HyperPodIssueReportCollector:
         
         return instance_ids
     
-    def generate_collector_script(self, commands: List[str]) -> str:
+    def generate_collector_script(self) -> str:
         """Generate the bash script that will run on each node.
         Instance group and ID are passed as environment variables.
         Script content varies based on cluster type (EKS vs Slurm)."""
@@ -472,24 +472,6 @@ class HyperPodIssueReportCollector:
                 "",
             ])
         
-        # Add each command to the script
-        for i, cmd in enumerate(commands, 1):
-            # Sanitize command for filename - replace problematic characters
-            safe_name = cmd.replace(' ', '_').replace('/', '_').replace('|', '_').replace('>', '_').replace('<', '_').replace('&', '_').replace(';', '_').replace('(', '_').replace(')', '_').replace('$', '_').replace('`', '_').replace('"', '_').replace("'", '_')[:50]
-            output_file = f"command_{i:02d}_{safe_name}.txt"
-
-            # Use shlex.quote() to safely escape the command for display in echo
-            quoted_cmd = shlex.quote(cmd)
-
-            cmd_line = f"{cmd} > \"${{OUTPUT_DIR}}/{output_file}\" 2>&1 || echo \"Command failed with exit code $?\" >> \"${{OUTPUT_DIR}}/{output_file}\""
-
-            script_lines.extend([
-                f"# Command {i}",
-                f"echo 'Running: '{quoted_cmd}",
-                cmd_line,
-                "",
-            ])
-        
         # Add S3 upload logic with new filename format
         script_lines.extend([
             "# Upload results to S3",
@@ -526,7 +508,7 @@ class HyperPodIssueReportCollector:
             raise ValueError("Cluster ID is required for HyperPod SSM targets")
         return f"sagemaker-cluster:{self.cluster_id}_{instance_group_name}-{instance_id}"
     
-    def execute_collection_on_node(self, node: Dict, commands: List[str], script_s3_uri: str) -> Dict:
+    def execute_collection_on_node(self, node: Dict, script_s3_uri: str) -> Dict:
         """Execute the collection script on a single node via SSM using pexpect."""
         instance_id = node['InstanceId']
         instance_group = node.get('NodeGroup', 'unknown')
@@ -770,10 +752,10 @@ class HyperPodIssueReportCollector:
                 except Exception:  # nosec B110 - best-effort cleanup
                     pass
     
-    def execute_with_retry(self, node: Dict, commands: List[str], script_s3_uri: str, max_retries: int = 3) -> Dict:
+    def execute_with_retry(self, node: Dict, script_s3_uri: str, max_retries: int = 3) -> Dict:
         """Execute collection on a node with exponential backoff on throttling errors."""
         for attempt in range(max_retries):
-            result = self.execute_collection_on_node(node, commands, script_s3_uri)
+            result = self.execute_collection_on_node(node, script_s3_uri)
             
             error_msg = result.get('Error', '')
             if 'ThrottlingException' in error_msg or 'Rate exceeded' in error_msg:
@@ -788,7 +770,7 @@ class HyperPodIssueReportCollector:
         
         return result
 
-    def collect_reports(self, commands: List[str], instance_groups: Optional[List[str]] = None, instance_ids: Optional[List[str]] = None, max_workers: int = 16):
+    def collect_reports(self, instance_groups: Optional[List[str]] = None, instance_ids: Optional[List[str]] = None, max_workers: int = 16):
         """Collect reports from all nodes, specific instance groups, or specific instance IDs.
         
         For Slurm clusters, instance_ids can be either:
@@ -848,12 +830,10 @@ class HyperPodIssueReportCollector:
         elif self.cluster_type == 'slurm':
             print(f"Default collections: nvidia-smi, nvidia-bug-report, sinfo, Slurm services, Slurm config, Slurm logs, system logs")
         
-        if commands:
-            print(f"Additional commands: {', '.join(commands)}")
         print("-" * 60)
-        
+
         # Generate and upload the collector script once
-        script_content = self.generate_collector_script(commands)
+        script_content = self.generate_collector_script()
         script_key = f"{self.report_s3_key}/collector_script.sh"
         
         try:
@@ -874,7 +854,7 @@ class HyperPodIssueReportCollector:
         
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             future_to_node = {
-                executor.submit(self.execute_with_retry, node, commands, script_s3_uri): node
+                executor.submit(self.execute_with_retry, node, script_s3_uri): node
                 for node in self.nodes
             }
             
@@ -1405,9 +1385,8 @@ Examples:
   # Basic usage - auto-detects cluster type
   python hyperpod_issue_report.py --cluster my-cluster --region us-west-2 --s3-path s3://my-bucket
 
-  # With custom prefix and additional commands
-  python hyperpod_issue_report.py --cluster my-cluster --region us-west-2 --s3-path s3://my-bucket/diagnostics \\
-    --command "df -h" --command "free -h"
+  # With custom S3 prefix
+  python hyperpod_issue_report.py --cluster my-cluster --region us-west-2 --s3-path s3://my-bucket/diagnostics
 
   # Target specific instance groups
   python hyperpod_issue_report.py --cluster my-cluster --region us-west-2 --s3-path s3://my-bucket \\
@@ -1422,7 +1401,6 @@ Examples:
     parser.add_argument('--cluster', '-c', required=True, help='HyperPod cluster name (EKS or Slurm)')
     parser.add_argument('--region', '-r', help='AWS region (uses default boto3 region if not specified)')
     parser.add_argument('--s3-path', '-s', required=True, help='S3 path for storing reports (e.g., s3://bucket-name/prefix or s3://bucket-name)')
-    parser.add_argument('--command', '-cmd', action='append', help='Additional command to execute on nodes (can be specified multiple times)')
     parser.add_argument('--instance-groups', '-g', nargs='+', help='Target specific instance groups (e.g., --instance-groups worker1 worker2)')
     parser.add_argument('--max-workers', '-w', type=int, default=16, help='Maximum concurrent SSM sessions (default: 16, reduce if hitting throttling)')
     parser.add_argument('--nodes', '-n', nargs='+', help='Target specific nodes: instance IDs (i-*), EKS node names (hyperpod-i-*), or Slurm node names (ip-*)')
@@ -1442,16 +1420,8 @@ Examples:
             region=args.region,
             debug=args.debug
         )
-        
-        # User-specified commands
-        commands = []
-        
-        # Add any user-specified commands
-        if args.command:
-            commands.extend(args.command)
-        
+
         collector.collect_reports(
-            commands=commands,
             instance_groups=args.instance_groups,
             instance_ids=args.nodes,
             max_workers=args.max_workers


### PR DESCRIPTION
Removes the `--command`/`-cmd` option from the `hyperpod-issue-report` skill.

This is a functional removal of a documented, user-facing capability — not a dead-code cleanup. The flag worked end to end when passed: `generate_collector_script` interpolated each value into the generated bash collector script, and each command's output was written to `command_{NN}_<sanitized_name>.txt` inside `${OUTPUT_DIR}`, tarballed, and uploaded to S3 alongside the built-in diagnostics.

No caller in this repo passed it, but the intended invocation path was agent-mediated rather than hardcoded: `SKILL.md` step 1 instructed the agent to collect "Additional commands to run on nodes" from the user, `SKILL.md` advertised `--command` in the `--help` list, and `references/collection-details.md` documented the resulting `command_NN_*.txt` artifact. So agent-visible behavior changes here, and anyone who previously supplied commands through that prompt will no longer see those files in the bundle.

### Why remove it

The diagnostics the skill actually relies on are built into the generated script — `sinfo`, `nvidia-smi`, `nvidia-bug-report.sh`, `df`, `dmesg`, systemd unit status, Slurm config and logs, the EKS log collector — which covers the cases the removed `--help` examples illustrated (`df -h`, `free -h`).

It also removes an unquoted interpolation. The deleted line built the executed command as `f"{cmd} > ..."` with no quoting, while `shlex.quote` was applied only to the adjacent `echo` display line. That script is uploaded to S3 and executed on every targeted node, so shell metacharacters in a `--command` value were shell metacharacters on the fleet. That is inherent to an arbitrary-command feature rather than a defect in it, but deleting the feature does reduce attack surface, and doing so is preferable to bolting validation onto a capability with no callers. A metacharacter allowlist would have had to reject pipes and redirects to mean anything, and an opt-in override flag would just relocate the same path behind a second flag.

### Changes

- Remove `--command`/`-cmd`, the per-command interpolation loop, and its output-filename sanitization.
- Remove the `commands` parameter from `generate_collector_script`, `execute_collection_on_node`, `execute_with_retry`, and `collect_reports`. Two of these were genuinely dead: `execute_collection_on_node` accepted the parameter and never read it (it builds its SSM invocation from `script_s3_uri`), and `execute_with_retry` only threaded it through. `generate_collector_script` and `collect_reports` did use it.
- Remove the option from `SKILL.md` (both the step-1 input list and the `--help` line) and the `command_NN_*.txt` section from `references/collection-details.md`.
- Bump the `sagemaker-ai` plugin `1.2.1` → `1.3.0` in all three manifests. Minor rather than patch, matching the minor #251 (`9545072`) took for renaming `--resume` → `--resume-incomplete`, since `SKILL.md` made this agent-visible rather than merely internal.

### Known gap

`hyperpod-ssm` covers ad-hoc command execution on a node, but it is not a complete substitute: it returns stdout to the caller one node at a time with no `tar`/S3 bundling, so "capture this extra output *inside* the support bundle" has no direct replacement. Given the built-ins already cover the common diagnostics, the practical gap is small — recording it so the tradeoff is explicit.

### Testing

- Generated collector scripts are byte-identical for both cluster types (Slurm 117 lines, EKS 133 lines); every built-in diagnostic, the tarball step, and the S3 upload are unchanged. Verified by generating both and asserting no `command_` or `Running: ` residue remains.
- `generate_collector_script()` now takes no arguments, so the removed path is unreachable programmatically as well as from the CLI.
- `--command` is now an `argparse` error (exit 2).
- Verified live against a single-node Slurm HyperPod cluster end to end: cluster describe → Slurm detection → node enumeration → script upload → SSM session → on-node execution → tarball → upload → summary. The resulting bundle contained 66 entries (6.8 MB) of real diagnostics — Slurm config and logs, `dmesg`, `syslog`, systemd units, `resource_config.json`, and 28 HyperPod cluster-agent logs.
- `python3 -m py_compile` clean; `bandit` reports no issues; `node tools/validate-cross-refs.cjs` reports 0 errors.

#### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agent-plugins/blob/main/LICENSE).
