### PR TITLE
feat: aws-transform plugin 1.7.0 — continuous-modernization actionable errors

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -133,7 +133,7 @@
         "transform",
         "continuous modernization"
       ],
-      "version": "1.6.0"
+      "version": "1.7.0"
     },
     {
       "category": "development",

--- a/plugins/aws-transform/.claude-plugin/plugin.json
+++ b/plugins/aws-transform/.claude-plugin/plugin.json
@@ -31,5 +31,5 @@
   "license": "Apache-2.0",
   "name": "aws-transform",
   "repository": "https://github.com/awslabs/agent-plugins",
-  "version": "1.6.0"
+  "version": "1.7.0"
 }

--- a/plugins/aws-transform/.codex-plugin/plugin.json
+++ b/plugins/aws-transform/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-transform",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Migrate, modernize, and upgrade codebases to AWS. Transforms .NET Framework to .NET 8/10, mainframe COBOL to Java, VMware VMs to EC2, SQL Server to Aurora, and upgrades Java/Python/Node.js versions and AWS SDKs. AWS Transform - continuous modernization analyzes codebases for tech debt, security issues, and upgrade opportunities, then remediates them.",
   "author": {
     "name": "Amazon Web Services",

--- a/plugins/aws-transform/skills/aws-transform/references/continuous-modernization-analysis.md
+++ b/plugins/aws-transform/skills/aws-transform/references/continuous-modernization-analysis.md
@@ -262,3 +262,22 @@ atx ct analysis run --type tech-debt-comprehensive --source <name> --tags team=a
 - If `~/.aws/atx/settings.json` defines `applyTags` (an array of tag maps), those defaults are applied automatically even without explicit `--tags`. An explicit `--tags` override merges **per key** over the settings defaults.
 
 See the [source](continuous-modernization-source.md) skill's Tags section for the full schema, merge semantics, and error behavior.
+
+## Prerequisites & errors
+
+AWS credentials must be valid and the CLI must be able to reach the AWS Transform
+backend before starting or reading an analysis. See the [troubleshooting](continuous-modernization-troubleshooting.md)
+skill for the full actionable-error reference. Common cases:
+
+- **`command not found: atx`** — the CLI isn't installed/on PATH. Install it (see
+  the `setup` skill) and verify with `atx --version`.
+- **Connection error** — the CLI can't reach the AWS Transform backend: refresh AWS credentials and confirm `AWS_REGION` is a supported region, then retry.
+- **`AccessDenied` / 403** — refresh AWS credentials,
+  confirm the role's permissions and `AWS_REGION`, then retry.
+- **`required option '--type <type>' not specified`** — `--type` takes a value; run
+  `atx ct analysis run --help` for valid values (e.g. `--type tech-debt-comprehensive`).
+- **Security analysis reports COMPLETED with 0 findings after an error line** — this
+  is _not_ a clean result; the findings fetch failed. Retry; if it persists, verify
+  credentials/region and Security Agent access (`atx ct setup security-agent`).
+- **Analysis stuck / no progress** — do not report success; check `atx ct analysis list`
+  and surface the actual status.

--- a/plugins/aws-transform/skills/aws-transform/references/continuous-modernization-findings.md
+++ b/plugins/aws-transform/skills/aws-transform/references/continuous-modernization-findings.md
@@ -110,3 +110,18 @@ atx ct remediation create --ids <finding-id1,finding-id2> --name "Fix name" --te
 - **Tech-debt / upgrade findings** route to an ATX transform (PR/CR).
 
 See the [remediation](continuous-modernization-remediation.md) skill for outcomes by source provider and for handling findings without a `fix` field.
+
+## Prerequisites & errors
+
+Before listing findings, AWS credentials must be valid and the CLI must be able
+to reach the AWS Transform backend (on a connection error, refresh credentials and confirm `AWS_REGION`). See the [troubleshooting](continuous-modernization-troubleshooting.md)
+skill for the full actionable-error reference.
+
+**An empty findings list is not automatically "clean."** Before reporting "no
+findings":
+
+- If the read errored (auth/connection), surface the error — do not report `0`.
+- Confirm `AWS_REGION` matches where the analysis ran (findings are region-scoped).
+- Confirm an analysis has actually completed (`atx ct analysis list`); no completed
+  analysis means there is nothing to list yet, not a clean bill of health.
+- On `AccessDenied` / 403: credentials likely expired — refresh them and retry.

--- a/plugins/aws-transform/skills/aws-transform/references/continuous-modernization-guide.md
+++ b/plugins/aws-transform/skills/aws-transform/references/continuous-modernization-guide.md
@@ -108,7 +108,7 @@ Explain: "Where should analysis and remediations run?
 - Fargate (recommended) — Managed containers. Scales automatically.
 - EC2 — Your own instance. Good for existing build servers."
 
-If EC2, follow the `/ec2-execution` skill (existing instance: provide instance ID or IP; new instance: launch with continuous modernization runtime pre-installed). If Fargate, follow the `/batch-execution` skill (creates ECS cluster, task definition, IAM roles).
+If EC2, follow the `/ec2-execution` skill (existing instance: provide instance ID or IP; new instance: launch with AWS Transform - continuous modernization runtime pre-installed). If Fargate, follow the `/batch-execution` skill (creates ECS cluster, task definition, IAM roles).
 
 After completion, move to Step 4.
 
@@ -237,10 +237,15 @@ When all steps are done, show a recap of what was accomplished in this session. 
 2. **Explain briefly, then ask.** 1-2 sentences of context max.
 3. **Offer defaults.** Have a recommended option. Make it easy to proceed.
 4. **Show commands.** Always display the `atx ct` command you're running so the user learns the CLI.
-5. **Handle errors plainly.** Say what failed, offer a fix or alternative:
-   - Startup/credentials error → "I couldn't reach the AWS Transform backend. Let's check your AWS credentials (refresh them if they've expired) and that you picked a supported region."
-   - Invalid token → "That token didn't work. Make sure it has `repo` scope."
-   - No repos found → "No repos found in that source. Double-check the org name or path."
+5. **Handle errors plainly.** Say what failed AND the next step — never a bare
+   error, and never an empty result presented as success. Common cases (full
+   reference: the [troubleshooting](continuous-modernization-troubleshooting.md) skill):
+   - `command not found: atx` → "The `atx` CLI isn't installed or isn't on your PATH. Let's install it." (see the `setup` skill), then verify with `atx --version`.
+   - Startup / can't reach backend → "I couldn't reach the AWS Transform backend. Let's check your AWS credentials (refresh them if they've expired) and that you picked a supported region."
+   - Connection error / `ECONNREFUSED` → "I couldn't reach the AWS Transform backend. Refresh your AWS credentials and confirm `AWS_REGION` is a supported region, then retry."
+   - Invalid/expired token → "That token didn't work. Make sure it has `repo` scope (and is SSO-authorized for the org)."
+   - `AccessDenied` / 403 → "Your AWS credentials look expired. Refresh them and confirm `AWS_REGION`, then retry."
+   - No repos / no findings → don't assume it's clean: check credentials, region, and whether an analysis has run before reporting "nothing found." Then, if genuinely empty → "No repos found in that source. Double-check the org name or path (for `--provider local`, `--path` must be the parent directory containing the repos)."
 6. **Let them skip.** "skip", "later", "not now" — move on.
 7. **Let them go back.** If they want to redo a step, accommodate.
 8. **Show progress.** For long operations, show status.

--- a/plugins/aws-transform/skills/aws-transform/references/continuous-modernization-remediation.md
+++ b/plugins/aws-transform/skills/aws-transform/references/continuous-modernization-remediation.md
@@ -189,3 +189,19 @@ atx ct remediation create --ids <id1,id2> --name "Fix name" --tags team=alpha,en
 - If `~/.aws/atx/settings.json` defines `applyTags` (an array of tag maps), those defaults are applied automatically even without explicit `--tags`. An explicit `--tags` override merges **per key** over the settings defaults.
 
 See the [source](continuous-modernization-source.md) skill's Tags section for the full schema, merge semantics, and error behavior.
+
+## Prerequisites & errors
+
+Remediation shells out to `git`, `atx`, and any provider-specific CLIs, and needs
+valid AWS + provider credentials. See the
+[troubleshooting](continuous-modernization-troubleshooting.md) skill for
+the full actionable-error reference. Common cases:
+
+- **`Required CLI "<tool>" was not found on PATH`** — install the named tool and
+  ensure it's on PATH (the error prints the searched PATH and an install hint).
+- **Connection error** — the CLI can't reach the AWS Transform backend: refresh AWS credentials and confirm `AWS_REGION` is a supported region, then retry.
+- **`AccessDenied` / 403 (AWS)** — refresh AWS credentials, confirm `AWS_REGION`, then retry.
+- **`401` from the provider** — the PAT is invalid/expired; re-add the source with a
+  valid token (`repo` scope; SSO-authorized for the org if required).
+- **A repo shows `blocked` / `failed`** — surface the per-repo error rather than
+  reporting the remediation as done; retry that repo after fixing the cause.

--- a/plugins/aws-transform/skills/aws-transform/references/continuous-modernization-setup.md
+++ b/plugins/aws-transform/skills/aws-transform/references/continuous-modernization-setup.md
@@ -97,4 +97,4 @@ To have the CLI automatically apply tags to every resource it creates (sources, 
 - `--status` checks current state: `configured`, `setup_in_progress`, `failed`, or `not_configured`.
 - `--delete` tears down AWS resources (CloudFormation stack, S3 bucket, config).
 - Requires valid AWS credentials (`aws sts get-caller-identity` must succeed).
-- If credentials are expired, ask the user to refresh them first (`ada credentials update`).
+- If credentials are expired, ask the user to refresh them first.

--- a/plugins/aws-transform/skills/aws-transform/references/continuous-modernization-status.md
+++ b/plugins/aws-transform/skills/aws-transform/references/continuous-modernization-status.md
@@ -10,3 +10,16 @@ description: Show AWS Transform - continuous modernization (continuous moderniza
 ```bash
 atx ct status [--source <name>]
 ```
+
+## Errors & empty results
+
+`status` is often the first command a returning user runs, so treat its failures
+as onboarding-critical. Never present a failed read as a clean dashboard of
+zeros — see the `troubleshooting` skill for the full reference.
+
+| What you see                                | What it means                                                        | What to tell the user                                                                                                      |
+| ------------------------------------------- | -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| A count shows `unavailable (read failed …)` | That sub-query (repos or findings) failed — it is **not** actually 0 | Surface the warning: credentials may have expired or `AWS_REGION` may not match where resources live. Re-run after fixing. |
+| Connection error                            | The CLI can't reach the AWS Transform backend                        | Refresh AWS credentials and confirm `AWS_REGION` matches a supported region; then retry.                                   |
+| `AccessDenied` / 403                        | AWS credentials expired or the principal isn't authorized            | Refresh credentials, confirm the role's permissions and `AWS_REGION`, then retry.                                          |
+| All counts genuinely 0 on first use         | Nothing set up yet                                                   | Guide them to add a source and run discovery — not an error.                                                               |

--- a/plugins/aws-transform/skills/aws-transform/references/continuous-modernization-troubleshooting.md
+++ b/plugins/aws-transform/skills/aws-transform/references/continuous-modernization-troubleshooting.md
@@ -1,9 +1,58 @@
 ---
 name: troubleshooting
-description: Troubleshooting guide for issues that occur during setup and execution of AWS Transform continuous modernization.
+description: Consolidated actionable-error reference for AWS Transform continuous modernization. Every common failure mode with what went wrong and the exact next step. Other CM skills link here.
 ---
 
-# Common Errors
+# Troubleshooting — Actionable Errors
+
+This is the single reference for the common failure modes of continuous
+modernization. **Rule: never surface a bare error and never present an empty
+result as success.** For every failure, tell the user (1) what went wrong and
+(2) the exact next step. When a command returns nothing, first decide whether it
+is genuinely empty or actually a failure (see "Empty results are not success"),
+then respond accordingly.
+
+## Fast triage — match the symptom
+
+| Symptom the user sees                                                     | Most likely cause                                                                                                           | What to tell the user + next step                                                                                                                                                                                                  |
+| ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `command not found: atx` / `atx: not found`                               | The AWS Transform CLI (`atx`) is not installed or not on PATH                                                               | "The `atx` CLI isn't installed (or isn't on your PATH)." Install it (see the `setup` skill), reopen the shell, and verify with `atx --version`.                                                                                    |
+| `atx ct` reports `unknown command 'ct'`                                   | The shell ran an `atx` that lacks the continuous-modernization commands (local resolution, NOT a credential/region problem) | See "`atx ct` reports `unknown command 'ct'`" below — inspect `type -a atx` and pick the smallest PATH correction.                                                                                                                 |
+| `atx` runs but behaves oddly / wrong version                              | A different binary named `atx` is shadowing the real one on PATH                                                            | Run `which -a atx` to list all matches. The real AWS Transform CLI must come first; remove or reorder the shadowing entry, then re-verify with `atx --version`.                                                                    |
+| Connection error / `ECONNREFUSED` / "Is the server running?"              | The CLI can't reach the AWS Transform backend                                                                               | Refresh AWS credentials and confirm `AWS_REGION` matches a supported region; then retry.                                                                                                                                           |
+| `AccessDenied` / `UnauthorizedException` / 403                            | AWS credentials expired, or the IAM principal lacks permission, or wrong region                                             | "Your AWS credentials look invalid, expired, or unauthorized." Refresh them, confirm the calling role has access, and confirm `AWS_REGION` is a supported region. Then retry.                                                      |
+| `401` from GitHub/GitLab/Bitbucket                                        | Provider token missing, invalid, or expired                                                                                 | "The provider rejected your token." Re-add the source with a valid PAT: `atx ct source add --name <name> --provider <p> --org <org> --token <PAT>`. The PAT needs the `repo` scope; for SSO orgs, authorize the token for the org. |
+| `discovery scan` reports **0 repos**                                      | `--path` points at a repo instead of its parent, wrong org/identifier, or an empty source                                   | "Found 0 repositories under `<source>`." Check the org/identifier is correct; for `--provider local`, `--path` must be the **parent** directory that _contains_ Git repos, not a repo itself.                                      |
+| Analysis / findings list is **empty** but shouldn't be                    | Wrong `AWS_REGION` (resources are region-scoped), analysis not run yet, or a read that silently failed                      | "No results found." Confirm `AWS_REGION` matches where your resources live, that an analysis has completed (`atx ct analysis list`), and re-run the read. If a read errored, surface the error — do not report "0".                |
+| Security analysis shows **COMPLETED with 0 findings** after an error line | Findings could not be retrieved from the Security Agent                                                                     | This is **not** a clean result. Retry the analysis; if it persists, verify AWS credentials/region and Security Agent access (`atx ct setup security-agent`).                                                                       |
+| `error: required option '--type <type>' not specified`                    | A required flag is missing or was transposed                                                                                | Run the command with `--help` to see valid options and values. Note `--type` takes a value, e.g. `--type tech-debt-comprehensive`; don't pass the type as a bare flag like `--tech-debt-quick`.                                    |
+| `error: unknown option '--xyz'` with `(Did you mean ...?)`                | A misspelled or wrong flag                                                                                                  | Use the suggested flag, or run the command with `--help` for the full list.                                                                                                                                                        |
+| 5xx / `InternalServerException` / throttling                              | Transient backend/infra issue                                                                                               | "The service hit a transient error." Retry shortly; if it persists, capture the Request ID from the message and contact support.                                                                                                   |
+| Write to `~/.atxct` fails ("File access is restricted…")                  | Workspace folder access restriction                                                                                         | See "Error writing files to the `~/.atxct` folder" below — find another way to read/write it; there is no alternative location.                                                                                                    |
+
+## Empty results are not success
+
+A command that returns `0 repos`, `0 findings`, or an empty list can mean either
+"genuinely nothing" **or** "an underlying call failed." Never present the second
+as the first. Before saying "nothing found":
+
+1. **Check credentials** — a plain `atx ct findings list` / `analysis list` /
+   `status` can return empty if AWS credentials expired. If unsure, run
+   `aws sts get-caller-identity`; if it fails, refresh credentials and retry.
+2. **Check region** — resources are region-scoped. Empty results with valid
+   credentials often mean `AWS_REGION` doesn't match where the resources live.
+3. **Check reachability** — a connection error mid-read can look like empty
+   output. Run a real read such as `atx ct analysis list --json` and branch on the
+   error: an auth error → refresh AWS credentials; a
+   region mismatch → set `AWS_REGION`; a genuinely empty list → treat as empty.
+4. **Then, and only then**, report a genuine empty state — with the specific
+   thing to check (org name, `--path` parent directory, whether an analysis has
+   run yet).
+
+The CLI itself now distinguishes these: `atx ct status` prints
+`unavailable (read failed …)` instead of `0` when a sub-query fails, and
+`discovery scan` raises a real auth/infra error instead of silently returning 0
+repos. Mirror that behavior in what you tell the user.
 
 ## `atx ct` reports `unknown command 'ct'`
 
@@ -22,3 +71,11 @@ If multiple candidates are listed, test paths returned by `type -a atx` directly
 ## Error writing files to the `~/.atxct` folder
 
 If attempting to read or write files to the user's `~/.atxct` folder fails due to an error similar to "File access is restricted to the open workspace folders", write a script or find another way to read/write to this directory -- there is no substitute/alternative location for files in `~/.atxct` so be sure to find a way to do it.
+
+## Prerequisites checklist (run when anything fails unexpectedly)
+
+- `atx --version` — the CLI is installed and on PATH.
+- `atx ct analysis list --json` — the CLI can reach the backend (an auth/region error here points at credentials or `AWS_REGION`, not an empty result).
+- `aws sts get-caller-identity` — AWS credentials are present and valid.
+- `echo $AWS_REGION` — set, and matches where your resources live.
+- For a provider source: the PAT is valid and has the `repo` scope (SSO-authorized if required).


### PR DESCRIPTION
Syncs the `aws-transform` continuous-modernization skill updates from the internal source (release skill-1.7.0).

**Changes**
- Actionable error guidance on failure paths — `atx ct` commands no longer surface as silent empty results.
- Bumps the `aws-transform` plugin version 1.6.0 → 1.7.0 (`.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, and the marketplace entry).

6 `continuous-modernization-*.md` reference files updated; no manifest/schema changes beyond the version bump.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agent-plugins/blob/main/LICENSE).