### PR TITLE
fix(deploy-on-aws): repair defusedxml diagram fixers

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -78,6 +78,10 @@ run = [
 # VALIDATION
 # =============
 
+[tasks."test:deploy-on-aws-diagrams"]
+description = "Run deploy-on-aws diagram runtime regression tests"
+run = "uv run --with-requirements plugins/deploy-on-aws/scripts/requirements.txt python -m unittest discover -s plugins/deploy-on-aws/scripts/tests -p 'test_*.py'"
+
 [tasks."validate:refs"]
 description = "Detect broken links and orphaned reference files"
 run = "uv run tools/validate-references.py"
@@ -93,6 +97,7 @@ run = "uv run tools/validate-urls.py"
 [tasks.validate]
 description = "Run all validation checks"
 run = [
+    { task = "test:deploy-on-aws-diagrams" },
     { task = "validate:refs" },
     { task = "validate:size" }
 ]

--- a/plugins/deploy-on-aws/scripts/lib/_xml_format.py
+++ b/plugins/deploy-on-aws/scripts/lib/_xml_format.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Format an already-parsed XML tree without importing an XML parser."""
+
+from __future__ import annotations
+
+
+def indent_tree(tree, space: str = "  ") -> None:
+    """Add deterministic whitespace indentation to an in-memory XML tree."""
+    _indent_element(tree.getroot(), level=0, space=space)
+
+
+def _indent_element(element, *, level: int, space: str) -> None:
+    current_indent = "\n" + (space * level)
+    child_indent = current_indent + space
+    children = list(element)
+
+    if children:
+        if not element.text or not element.text.strip():
+            element.text = child_indent
+        for child in children:
+            _indent_element(child, level=level + 1, space=space)
+        last_child = children[-1]
+        if not last_child.tail or not last_child.tail.strip():
+            last_child.tail = current_indent
+
+    if level and (not element.tail or not element.tail.strip()):
+        element.tail = current_indent

--- a/plugins/deploy-on-aws/scripts/lib/fix_icon_colors.py
+++ b/plugins/deploy-on-aws/scripts/lib/fix_icon_colors.py
@@ -8,8 +8,13 @@ Fixes three types of issues:
 
 """
 
+from __future__ import annotations
+
 import argparse
+
 import defusedxml.ElementTree as ET
+
+from _xml_format import indent_tree
 
 # Broken shape names → correct shape names
 SHAPE_RENAMES: dict[str, str] = {
@@ -341,7 +346,7 @@ def main() -> None:
     if fixed > 0:
         print(f"Icons fixed: {fixed}")
         if not args.dry_run:
-            ET.indent(tree, space="  ")
+            indent_tree(tree, space="  ")
             tree.write(args.file, encoding="unicode", xml_declaration=False)
             print(f"Written: {args.file}")
         else:

--- a/plugins/deploy-on-aws/scripts/lib/fix_nesting.py
+++ b/plugins/deploy-on-aws/scripts/lib/fix_nesting.py
@@ -15,8 +15,13 @@ This script:
 
 """
 
+from __future__ import annotations
+
 import argparse
+
 import defusedxml.ElementTree as ET
+
+from _xml_format import indent_tree
 
 
 def get_style_dict(style_str: str) -> dict[str, str]:
@@ -157,7 +162,7 @@ def main() -> None:
     if fixed > 0:
         print(f"Regions fixed: {fixed}")
         if not args.dry_run:
-            ET.indent(tree, space="  ")
+            indent_tree(tree, space="  ")
             tree.write(args.file, encoding="unicode", xml_declaration=False)
             print(f"Written: {args.file}")
         else:

--- a/plugins/deploy-on-aws/scripts/lib/fix_step_badges.py
+++ b/plugins/deploy-on-aws/scripts/lib/fix_step_badges.py
@@ -17,11 +17,16 @@ Improved algorithm (v2):
 
 """
 
+from __future__ import annotations
+
 import argparse
+from dataclasses import dataclass
 import math
 import re
+
 import defusedxml.ElementTree as ET
-from dataclasses import dataclass
+
+from _xml_format import indent_tree
 
 
 @dataclass
@@ -483,7 +488,7 @@ def main() -> None:
     print(f"Badges moved: {moved}")
 
     if not args.dry_run and moved > 0:
-        ET.indent(tree, space="  ")
+        indent_tree(tree, space="  ")
         tree.write(args.file, encoding="unicode", xml_declaration=False)
         print(f"Written: {args.file}")
     elif args.dry_run and moved > 0:

--- a/plugins/deploy-on-aws/scripts/lib/post_process_drawio.py
+++ b/plugins/deploy-on-aws/scripts/lib/post_process_drawio.py
@@ -10,13 +10,16 @@ Chains all fixers in sequence:
 Reads JSON from stdin (PostToolUse hook format) or accepts file path as argument.
 """
 
+from __future__ import annotations
+
 import argparse
 import importlib.util
 import json
 import os
 import sys
-import defusedxml.ElementTree as ET
 from pathlib import Path
+
+import defusedxml.ElementTree as ET
 
 MAX_FILE_SIZE = 2 * 1024 * 1024  # 2 MB
 
@@ -27,8 +30,19 @@ SCRIPT_DIR = Path(__file__).parent
 
 def _import_from(module_name: str, file_name: str):
     spec = importlib.util.spec_from_file_location(module_name, SCRIPT_DIR / file_name)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load draw.io fixer module: {file_name}")
     mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
+    previous = sys.modules.get(module_name)
+    sys.modules[module_name] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except Exception:
+        if previous is None:
+            sys.modules.pop(module_name, None)
+        else:
+            sys.modules[module_name] = previous
+        raise
     return mod
 
 
@@ -199,7 +213,6 @@ def fix_placement(tree: ET.ElementTree, verbose: bool = False) -> int:
             cloud_x = aws_cloud_geom["x"]
             cloud_x2 = cloud_x + aws_cloud_geom["w"]
             actor_x = g["x"]
-            actor_x2 = actor_x + g["w"]
 
             # Check if actor overlaps AWS Cloud horizontally
             if actor_x >= cloud_x and actor_x < cloud_x2:

--- a/plugins/deploy-on-aws/scripts/tests/test_drawio_runtime.py
+++ b/plugins/deploy-on-aws/scripts/tests/test_drawio_runtime.py
@@ -1,0 +1,134 @@
+"""Regression tests for the deploy-on-aws draw.io runtime."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+import defusedxml.ElementTree as ET
+
+
+LIB_DIR = Path(__file__).resolve().parents[1] / "lib"
+MISSING = object()
+FIXTURE = """\
+<mxfile host="Electron">
+  <diagram name="Page-1">
+    <mxGraphModel>
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="svc" parent="1" vertex="1"
+          style="rounded=1;fillColor=#000000;strokeColor=#000000;fontColor=#000000;">
+          <mxGeometry x="10" y="10" width="120" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="lambda" parent="svc" vertex="1"
+          style="shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.lambda;fillColor=#000000;">
+          <mxGeometry x="36" y="24" width="48" height="48" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>
+"""
+
+
+def load_module(module_name: str, file_name: str):
+    spec = importlib.util.spec_from_file_location(module_name, LIB_DIR / file_name)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load test module: {file_name}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(module_name, None)
+        raise
+    return module
+
+
+class DrawioRuntimeTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.defusedxml_exports = {
+            name: getattr(ET, name, MISSING)
+            for name in ("Element", "ElementTree", "indent")
+        }
+        cls.xml_format = load_module("_xml_format", "_xml_format.py")
+        cls.post_process = load_module(
+            "post_process_drawio_runtime_test", "post_process_drawio.py"
+        )
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        for module_name in (
+            "post_process_drawio_runtime_test",
+            "fix_step_badges",
+            "fix_nesting",
+            "fix_icon_colors",
+            "_xml_format",
+        ):
+            sys.modules.pop(module_name, None)
+
+    def write_fixture(self, directory: str) -> Path:
+        path = Path(directory) / "fixture.drawio"
+        path.write_text(FIXTURE, encoding="utf-8")
+        return path
+
+    def test_imports_do_not_patch_defusedxml_exports(self) -> None:
+        for name, expected in self.defusedxml_exports.items():
+            self.assertIs(getattr(ET, name, MISSING), expected)
+
+    def test_parser_free_indenter_preserves_parseable_xml(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = self.write_fixture(directory)
+            tree = ET.parse(path)
+
+            self.xml_format.indent_tree(tree)
+            tree.write(path, encoding="unicode", xml_declaration=False)
+
+            rendered = path.read_text(encoding="utf-8")
+            self.assertIn("\n  <diagram", rendered)
+            self.assertEqual(ET.parse(path).getroot().tag, "mxfile")
+
+    def test_individual_fixer_writes_with_parser_free_indentation(self) -> None:
+        fixer = sys.modules["fix_icon_colors"]
+        with tempfile.TemporaryDirectory() as directory:
+            path = self.write_fixture(directory)
+
+            with (
+                mock.patch.object(sys, "argv", ["fix_icon_colors.py", str(path)]),
+                contextlib.redirect_stdout(io.StringIO()),
+            ):
+                fixer.main()
+
+            rendered = path.read_text(encoding="utf-8")
+            self.assertIn("fillColor=#ED7100", rendered)
+            self.assertIn("\n  <diagram", rendered)
+            self.assertEqual(ET.parse(path).getroot().tag, "mxfile")
+
+    def test_unified_pipeline_dry_run_is_non_mutating(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = self.write_fixture(directory)
+            original = path.read_bytes()
+
+            with (
+                mock.patch.object(
+                    sys,
+                    "argv",
+                    ["post_process_drawio.py", "--dry-run", str(path)],
+                ),
+                contextlib.redirect_stdout(io.StringIO()),
+            ):
+                self.post_process.main()
+
+            self.assertEqual(path.read_bytes(), original)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- postpone runtime annotation evaluation in all four draw.io fixer modules so `defusedxml.ElementTree` remains the parser without resolving exports it does not provide
- replace the unavailable `ET.indent` call with a small parser-free formatter and make the dynamic loader safe for postponed dataclass annotations
- add regression coverage to the existing `mise run validate` path, with no new dependency

## Problem

With the declared `defusedxml>=0.7.1` dependency, the shipped diagram entrypoints fail at import time because `defusedxml.ElementTree` does not expose `Element`, `ElementTree`, or `indent`. This makes the deploy-on-aws post-processing hook fail before it can validate a generated diagram.

This addresses the runtime failure described in #154 and #167 and supersedes the closed approach in #172 without monkeypatching parser exports or reintroducing an unsafe parser import.

## Verification

- `mise run validate`
- `mise run lint`
- `mise run fmt:check`
- focused unittest suite: 4 passed
- Ruff 0.15.0: clean
- Bandit 1.9.3: clean
- vendored Semgrep scan: 789 rules, 0 findings
- all four shipped entrypoints executed successfully with `defusedxml==0.7.1`
- the shipped hook post-processed and validated a real 2,188 x 904 AWS draw.io diagram end to end

A complete local `mise run build` could not start because the temporary Mise bootstrap rejected its uv release attestation. The exact lint, validation, formatting, focused security, and real-diagram checks above were run directly; canonical GitHub CI remains the package-wide build authority.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agent-plugins/blob/main/LICENSE).