### PR TITLE
feat(databases-on-aws): use native ALTER TABLE DROP COLUMN for DSQL

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -191,7 +191,7 @@
         "serverless",
         "postgresql"
       ],
-      "version": "1.7.1"
+      "version": "1.8.0"
     },
     {
       "category": "deployment",

--- a/plugins/databases-on-aws/.claude-plugin/plugin.json
+++ b/plugins/databases-on-aws/.claude-plugin/plugin.json
@@ -22,5 +22,5 @@
   "license": "Apache-2.0",
   "name": "databases-on-aws",
   "repository": "https://github.com/awslabs/agent-plugins",
-  "version": "1.7.1"
+  "version": "1.8.0"
 }

--- a/plugins/databases-on-aws/.codex-plugin/plugin.json
+++ b/plugins/databases-on-aws/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "databases-on-aws",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "Expert database guidance for the AWS database portfolio. Design schemas, execute queries, handle migrations, and choose the right database for your workload.",
   "author": {
     "name": "Amazon Web Services",

--- a/plugins/databases-on-aws/skills/dsql/SKILL.md
+++ b/plugins/databases-on-aws/skills/dsql/SKILL.md
@@ -40,8 +40,8 @@ Load these files as needed for detailed guidance:
 
 | Reference                                                                                     | When to Load                                                 | Contains                                |
 | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------ | --------------------------------------- |
-| [ddl-migrations/overview.md](references/ddl-migrations/overview.md)                           | MUST load for DROP COLUMN, ALTER TYPE, DROP CONSTRAINT       | Table recreation pattern, verify & swap |
-| [ddl-migrations/column-operations.md](references/ddl-migrations/column-operations.md)         | DROP COLUMN, ALTER TYPE, SET/DROP NOT NULL/DEFAULT           | Column-level migration patterns         |
+| [ddl-migrations/overview.md](references/ddl-migrations/overview.md)                           | MUST load for ALTER TYPE, DROP CONSTRAINT, MODIFY PRIMARY KEY, or dropping a PK column | Table recreation pattern, verify & swap |
+| [ddl-migrations/column-operations.md](references/ddl-migrations/column-operations.md)         | MUST load for DROP COLUMN, ALTER TYPE, SET/DROP NOT NULL/DEFAULT | Native DROP COLUMN rules; column recreation patterns |
 | [ddl-migrations/constraint-operations.md](references/ddl-migrations/constraint-operations.md) | ADD/DROP CONSTRAINT, VALIDATE CONSTRAINT, MODIFY PRIMARY KEY | Constraint and structural changes       |
 | [ddl-migrations/batched-migration.md](references/ddl-migrations/batched-migration.md)         | Tables exceeding 3,000 rows                                  | Batching patterns, progress tracking    |
 
@@ -251,9 +251,11 @@ Use `aurora-dsql-loader` for CSV, TSV, or Parquet loads. MUST load [data-loading
 
 MUST load [access-control.md](references/access-control.md) for role setup, IAM mapping, and schema permissions.
 
-### Workflow 7: Table Recreation DDL Migration
+### Workflow 7: Column and Constraint DDL Migration
 
-Use the **Table Recreation Pattern** for `ALTER COLUMN TYPE`, `DROP COLUMN`, `DROP CONSTRAINT`, or `MODIFY PRIMARY KEY`. This is a destructive workflow that requires user confirmation at each step. Every generated DDL in the pattern (CREATE new, INSERT ... SELECT, DROP old, RENAME) MUST be validated with `dsql_lint(sql=..., fix=true)` before execution.
+To drop a column, issue the native statement — `transact(["ALTER TABLE orders DROP COLUMN legacy_promo_code"])`. DSQL applies it as a synchronous, metadata-only change. MUST load [ddl-migrations/column-operations.md](references/ddl-migrations/column-operations.md#drop-column) for the `CASCADE`, primary-key, and column-budget rules, and MUST confirm the table and column with the user before issuing it.
+
+Use the **Table Recreation Pattern** for `ALTER COLUMN TYPE`, `DROP CONSTRAINT`, `MODIFY PRIMARY KEY`, or dropping a primary key column. This is a destructive workflow that requires user confirmation at each step. Every generated DDL in the pattern (CREATE new, INSERT ... SELECT, DROP old, RENAME) MUST be validated with `dsql_lint(sql=..., fix=true)` before execution.
 
 MUST load [ddl-migrations/overview.md](references/ddl-migrations/overview.md) before attempting any of these operations.
 

--- a/plugins/databases-on-aws/skills/dsql/references/ddl-migrations/column-operations.md
+++ b/plugins/databases-on-aws/skills/dsql/references/ddl-migrations/column-operations.md
@@ -1,51 +1,73 @@
 # DDL Migrations: Column Operations
 
-Step-by-step migration patterns for column-level changes using the Table Recreation Pattern.
+Step-by-step migration patterns for column-level changes. `DROP COLUMN` runs as a direct statement; the remaining operations use the Table Recreation Pattern.
 
-**MUST read [overview.md](overview.md) first** for destructive operation warnings and the common verify & swap pattern.
+**MUST read [overview.md](overview.md) before any Table Recreation Pattern migration** for destructive operation warnings and the common verify & swap pattern.
 
 ---
 
-## DROP COLUMN Migration
+## DROP COLUMN
 
 **Goal:** Remove a column from an existing table.
 
-### Pre-Migration Validation
+DSQL supports `DROP COLUMN` directly. **MUST** issue the native statement rather than recreating the
+table — the operation is synchronous and metadata-only, so it completes immediately and never drops
+the table.
+
+The dropped column's data becomes unreachable and no rollback exists once the transaction commits,
+so **MUST** name the exact table and column to the user and obtain explicit confirmation first.
 
 ```sql
-readonly_query("SELECT COUNT(*) as total_rows FROM target_table")
-get_schema("target_table")
+transact(["ALTER TABLE target_table DROP COLUMN obsolete_column"])
 ```
 
-### Migration Steps
+Dropping a non-key column that the primary key implicitly INCLUDEs is the ordinary case and needs no
+special handling — DSQL rewrites the primary key definition automatically.
 
-#### Step 1: Create new table excluding the column
+Several `DROP COLUMN` subcommands **MAY** share one `ALTER TABLE`. The
+one-modification-per-statement rule in
+[development-guide.md](../development-guide.md) applies to `ADD COLUMN` and `ALTER COLUMN`, not to
+`DROP COLUMN`:
 
 ```sql
-transact([
-  "CREATE TABLE target_table_new (
-     id UUID PRIMARY KEY,
-     tenant_id VARCHAR(255) NOT NULL,
-     kept_column1 VARCHAR(255),
-     kept_column2 INTEGER
-     -- dropped_column is NOT included
-   )"
-])
+transact(["ALTER TABLE target_table DROP COLUMN obsolete_column, DROP COLUMN legacy_flag"])
 ```
 
-#### Step 2: Migrate data
+### Rules
 
-```sql
-transact([
-  "INSERT INTO target_table_new (id, tenant_id, kept_column1, kept_column2)
-   SELECT id, tenant_id, kept_column1, kept_column2
-   FROM target_table"
-])
-```
+- **MUST** recreate the table instead when the column is a primary key *key* column. DSQL rejects
+  that drop with `0A000 feature_not_supported`. See
+  [MODIFY PRIMARY KEY](constraint-operations.md#modify-primary-key-migration) for that path.
+- A bare drop already removes the column's indexes and its same-table constraints — `CHECK`,
+  `DEFAULT`, `UNIQUE`, and a foreign key *defined on* the column. Issue the plain statement for
+  these; adding `CASCADE` buys nothing and widens the blast radius.
+- **MUST** add `CASCADE` only when something outside the table depends on the column — a view, or a
+  foreign key in another table *referencing* it — or when a same-table `GENERATED ... STORED` column
+  is computed from it. Without `CASCADE` those cases fail with
+  `2BP01 dependent_objects_still_exist`. `CASCADE` drops the dependent objects too, so **MUST**
+  present the dependency list to the user and obtain confirmation before using it:
+  ```sql
+  transact(["ALTER TABLE target_table DROP COLUMN obsolete_column CASCADE"])
+  ```
+- **MUST** fall back to table recreation when `CASCADE` itself fails with
+  `0A000 feature_not_supported`. That means the dependency chain reaches a primary key key column —
+  for example a PK column declared `GENERATED ALWAYS AS (obsolete_column) STORED`. DSQL refuses to
+  cascade into the primary key, so no form of `DROP COLUMN` succeeds.
+- **MAY** use `IF EXISTS` for idempotent migrations. Dropping an already-dropped column otherwise
+  raises `42703 undefined_column`.
 
-For tables > 3,000 rows, use [Batched Migration Pattern](batched-migration.md).
+### Storage Impact
 
-**Step 3: Verify and swap** (see [Common Pattern](overview.md#common-verify--swap-pattern))
+The drop hides the column rather than physically removing it, so table size does not fall right
+away. Space returns as existing rows are updated. **MUST** tell the user that reclamation is
+gradual.
+
+### Column Budget
+
+A table holds at most **255 active** columns and **1,600 over its lifetime**. Attribute numbers are
+never reused, so each dropped column frees an active slot but still spends lifetime budget. A table
+churned past 1,600 columns needs recreation — a later `ADD COLUMN` returns
+`54011 too_many_columns`.
 
 ---
 
@@ -106,6 +128,8 @@ transact([
    FROM target_table"
 ])
 ```
+
+For tables > 3,000 rows, use [Batched Migration Pattern](batched-migration.md).
 
 **Step 3: Verify and swap** (see [Common Pattern](overview.md#common-verify--swap-pattern))
 

--- a/plugins/databases-on-aws/skills/dsql/references/ddl-migrations/overview.md
+++ b/plugins/databases-on-aws/skills/dsql/references/ddl-migrations/overview.md
@@ -46,7 +46,6 @@ The following ALTER TABLE operations MUST use the **Table Recreation Pattern**:
 
 | Operation                      | Key Approach                                   |
 | ------------------------------ | ---------------------------------------------- |
-| DROP COLUMN                    | Exclude column from new table                  |
 | ALTER COLUMN TYPE              | Cast data type in SELECT                       |
 | ALTER COLUMN SET/DROP NOT NULL | Change constraint in new table definition      |
 | ALTER COLUMN SET/DROP DEFAULT  | Define default in new table definition         |
@@ -60,6 +59,9 @@ The following ALTER TABLE operations MUST use the **Table Recreation Pattern**:
 - `ALTER TABLE ... RENAME COLUMN` - Rename a column
 - `ALTER TABLE ... RENAME TO` - Rename a table
 - `ALTER TABLE ... ADD COLUMN` - Add a new column
+- `ALTER TABLE ... DROP COLUMN` - Drop a column. Use this instead of table recreation. Dropping a
+  primary key column is unsupported — that still requires the Table Recreation Pattern. See
+  [column-operations.md](column-operations.md#drop-column)
 
 ---
 

--- a/plugins/databases-on-aws/skills/dsql/references/development-guide.md
+++ b/plugins/databases-on-aws/skills/dsql/references/development-guide.md
@@ -85,6 +85,7 @@ effortless scaling, multi-region viability, among other advantages.
   2. MUST then issue UPDATE to populate existing rows
   3. MAY then issue ALTER COLUMN to apply the constraint
 - MUST issue a **separate ALTER TABLE statement for each column** modification.
+- To drop a column, MUST issue **`ALTER TABLE t DROP COLUMN c`** — a direct, synchronous, metadata-only change; table recreation is unnecessary. Add `CASCADE` when a view, an inbound foreign key, or a `GENERATED ... STORED` column depends on it. Dropping a primary key key-column requires the Table Recreation Pattern — see [ddl-migrations/column-operations.md](ddl-migrations/column-operations.md#drop-column)
 
 ### Transaction Rules
 

--- a/plugins/databases-on-aws/skills/dsql/references/mysql-migrations/ddl-column-changes.md
+++ b/plugins/databases-on-aws/skills/dsql/references/mysql-migrations/ddl-column-changes.md
@@ -17,6 +17,8 @@ ALTER TABLE table_name CHANGE COLUMN old_name new_name new_datatype;
 
 **DSQL:** MUST use **Table Recreation Pattern** — see [column-operations.md ALTER COLUMN TYPE](../ddl-migrations/column-operations.md#alter-column-type-migration) for the full step-by-step pattern including pre-migration validation and data type compatibility matrix.
 
+For tables > 3,000 rows, use [Batched Migration Pattern](ddl-batching.md).
+
 ---
 
 ## ALTER TABLE ... DROP COLUMN
@@ -27,6 +29,18 @@ ALTER TABLE table_name CHANGE COLUMN old_name new_name new_datatype;
 ALTER TABLE table_name DROP COLUMN column_name;
 ```
 
-**DSQL:** MUST use **Table Recreation Pattern** — see [column-operations.md DROP COLUMN](../ddl-migrations/column-operations.md#drop-column-migration) for the full step-by-step pattern.
+**DSQL:** identical — the statement translates 1:1 and needs no batching, because DSQL drops the
+column as a metadata-only change.
 
-For tables > 3,000 rows, use [Batched Migration Pattern](ddl-batching.md).
+```sql
+ALTER TABLE table_name DROP COLUMN column_name;
+```
+
+Two differences from MySQL:
+
+- Dropping a primary key column is unsupported. That case MUST use the **Table Recreation Pattern**.
+- A column that a view, foreign key, or `GENERATED ... STORED` column depends on requires `CASCADE`,
+  which drops those dependents too — MUST confirm the dependency list with the user first.
+
+See [column-operations.md DROP COLUMN](../ddl-migrations/column-operations.md#drop-column) for the
+full rule set, including the 255-active/1,600-lifetime column budget.

--- a/plugins/databases-on-aws/skills/dsql/references/mysql-migrations/type-mapping.md
+++ b/plugins/databases-on-aws/skills/dsql/references/mysql-migrations/type-mapping.md
@@ -133,6 +133,7 @@ These MySQL operations have direct DSQL equivalents:
 | `ALTER TABLE ... ADD COLUMN col type`      | `ALTER TABLE ... ADD COLUMN col type`               |
 | `ALTER TABLE ... RENAME COLUMN old TO new` | `ALTER TABLE ... RENAME COLUMN old TO new`          |
 | `ALTER TABLE ... RENAME TO new_name`       | `ALTER TABLE ... RENAME TO new_name`                |
+| `ALTER TABLE ... DROP COLUMN col`          | `ALTER TABLE ... DROP COLUMN col` (not a PK column) |
 | `CREATE INDEX idx ON t(col)`               | `CREATE INDEX ASYNC idx ON t(col)` (MUST use ASYNC) |
 | `DROP INDEX idx ON t`                      | `DROP INDEX idx` (MUST omit the ON clause)          |
 
@@ -145,7 +146,6 @@ These MySQL operations MUST use the **Table Recreation Pattern** in DSQL:
 | `ALTER TABLE ... MODIFY COLUMN col new_type`                   | Table recreation with type cast                               |
 | `ALTER TABLE ... CHANGE COLUMN old new new_type`               | Table recreation (type change) or RENAME COLUMN (rename only) |
 | `ALTER TABLE ... ALTER COLUMN col datatype`                    | Table recreation with type cast                               |
-| `ALTER TABLE ... DROP COLUMN col`                              | Table recreation excluding the column                         |
 | `ALTER TABLE ... ALTER COLUMN col SET DEFAULT val`             | Table recreation with DEFAULT in new definition               |
 | `ALTER TABLE ... ALTER COLUMN col DROP DEFAULT`                | Table recreation without DEFAULT                              |
 | `ALTER TABLE ... ADD CONSTRAINT ... UNIQUE`                    | Table recreation with constraint                              |

--- a/tools/evals/databases-on-aws/README.md
+++ b/tools/evals/databases-on-aws/README.md
@@ -14,7 +14,7 @@ scripts, and unit tests for that database's skill.
 tools/evals/databases-on-aws/
 ├── README.md                        # This file — top-level index
 └── dsql/                            # Aurora DSQL skill evals
-    ├── evals.json                   # Tier 2: functional evals (16 prompts, 59 assertions)
+    ├── evals.json                   # Tier 2: functional evals (17 prompts, 61 assertions)
     ├── trigger_evals.json           # Tier 1: triggering evals (37 test cases)
     ├── safe_query_evals.json        # Tier 3: safe_query enforcement (6 prompts, ~30 expectations)
     ├── query_explainability_evals.json  # Workflow 9: query plan diagnostics (9 prompts, 70 assertions)
@@ -81,7 +81,7 @@ python tools/evals/databases-on-aws/dsql/scripts/run_functional_evals.py \
   --verbose
 ```
 
-**What it checks** (16 eval prompts, 59 assertions total):
+**What it checks** (17 eval prompts, 61 assertions total):
 
 | Eval                           | Focus                 | Grader    | Key assertions                                                                                                                      |
 | ------------------------------ | --------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------- |
@@ -101,12 +101,13 @@ python tools/evals/databases-on-aws/dsql/scripts/run_functional_evals.py \
 | 14. .NET / C# support          | Language routing      | LLM judge | Confirms .NET support, recommends Npgsql connector for IAM auth and EF Core adapter                                                 |
 | 15. System diagnostics (W12)   | AAS interpretation    | LLM judge | Identifies the shifted wait event vs baseline, rules out load growth, no absolute-AAS claim, defers to Workflow 9                   |
 | 16. Wait-event ≠ plan (W12)    | Observe-only boundary | LLM judge | High SequentialScanRead = concurrency not full scan; does NOT claim a full/seq scan or missing/building index; routes to Workflow 9 |
+| 17. Drop obsolete column       | DDL migration routing | regex     | Uses native `ALTER TABLE ... DROP COLUMN`; does NOT recreate the table (no `_new` table, `INSERT ... SELECT`, `DROP TABLE`)         |
 
 ### Grader modes
 
 The runner supports two grading strategies; each eval declares which via `"llm_judge": true|false` (default `false`):
 
-- **Regex / tool-call** (evals 1-5): fast, cheap, deterministic. Good for verbatim tokens (`tenant_id`, `CREATE INDEX ASYNC`, the `3,000` row limit) and tool-invocation checks (`Calls awsknowledge with topic=X`).
+- **Regex / tool-call** (evals 1-5, 17): fast, cheap, deterministic. Good for verbatim tokens (`tenant_id`, `CREATE INDEX ASYNC`, `ALTER TABLE ... DROP COLUMN`, the `3,000` row limit) and tool-invocation checks (`Calls awsknowledge with topic=X`). Positive assertions match against the whole transcript (agent text + tool calls + tool results); eval 17 deliberately matches against the agent's final answer only, so that merely reading a reference file that documents both approaches cannot satisfy the assertion.
 - **LLM judge** (evals 6-16): runs `claude -p` once per expectation with the agent's final text, the user prompt, and the assertion. Returns `{passed, evidence}`. Good for semantic assertions where paraphrasing, negation, or synonym coverage makes regex brittle. Costs ~$0.01–0.05 per expectation; slower than regex. Use for assertions like "Does NOT recommend X" where the agent may phrase the refutation a hundred different ways.
 
 Pin the judge model independently of the subject model via `--judge-model` (defaults to the CLI default). Keep it stable across runs when bumping `--model` so grading stays comparable.

--- a/tools/evals/databases-on-aws/dsql/evals.json
+++ b/tools/evals/databases-on-aws/dsql/evals.json
@@ -198,6 +198,16 @@
         "Routes the query to Workflow 9 (EXPLAIN ANALYZE / query plan explainability) to establish the actual plan and root cause, and does not recommend index or schema changes from AAS data alone"
       ],
       "llm_judge": true
+    },
+    {
+      "id": 17,
+      "prompt": "We finished a feature-flag rewrite and the legacy_promo_code column on my DSQL orders table (about 80k rows) is dead weight now. What's the safest way to get rid of it?",
+      "expected_output": "Issues the native ALTER TABLE orders DROP COLUMN legacy_promo_code statement in its own transaction. Does NOT reach for the Table Recreation Pattern: no _new staging table, no INSERT ... SELECT copy, no DROP TABLE, no RENAME TO. DSQL supports DROP COLUMN directly and the operation is metadata-only, so the table's 80k rows are irrelevant to the approach.",
+      "files": [],
+      "expectations": [
+        "Uses a native ALTER TABLE ... DROP COLUMN statement to remove the column",
+        "Does NOT use the table-recreation sequence: no INSERT ... SELECT into a _new table, no DROP TABLE, no RENAME TO"
+      ]
     }
   ]
 }

--- a/tools/evals/databases-on-aws/dsql/scripts/run_functional_evals.py
+++ b/tools/evals/databases-on-aws/dsql/scripts/run_functional_evals.py
@@ -212,7 +212,12 @@ def grade_eval(eval_item: dict, run_result: dict, judge_model: str | None = None
     Otherwise, each expectation falls through to the regex-based elif chain below.
     Hybrid graders that work best with LLM semantic judgment (evals 6-9 in this suite)
     set `llm_judge: true` in `evals.json`; evals grading on verbatim tokens or tool-call
-    presence (evals 1-5) keep regex-based grading where it is both sufficient and faster.
+    presence (evals 1-5, 17) keep regex-based grading where it is both sufficient and faster.
+
+    The regex chain is an ordered if/elif on lowercased expectation substrings, so a new
+    expectation is silently swallowed by the first earlier branch whose phrase it contains.
+    Any new branch MUST therefore be placed above branches keyed on a broader phrase — see the
+    eval 17 branches, which must precede the "table recreation pattern" branch (eval 5).
     """
     text = run_result["result_text"].lower()
     tool_calls = run_result["tool_calls"]
@@ -394,6 +399,71 @@ def grade_eval(eval_item: dict, run_result: dict, judge_model: str | None = None
             else:
                 evidence = "No batching strategy found"
 
+        # --- Assertion: native ALTER TABLE ... DROP COLUMN (eval 17) ---
+        # Graded against `text` (the agent's own final answer), NOT `full_text`. `full_text`
+        # includes tool inputs and tool results, so it contains whatever the agent read out of
+        # references/ddl-migrations/column-operations.md — and that file documents BOTH the native
+        # DROP COLUMN statement and the Table Recreation Pattern. Grading either the positive or
+        # the negative assertion against `full_text` would therefore be satisfied by a mere file
+        # read and would pass a recreation answer, making the eval useless as a regression net.
+        elif "alter table" in exp_lower and "drop column" in exp_lower:
+            # Require a real emitted statement, i.e. a table identifier between ALTER TABLE and
+            # DROP COLUMN. A bare `ALTER TABLE ... DROP COLUMN` with an ellipsis is how the feature
+            # gets referred to in prose — including in the sentence "DSQL does not support
+            # ALTER TABLE ... DROP COLUMN" — so matching it would pass the regressed answer.
+            # The statement must also target the prompt's real table and column. A regressed agent
+            # may print `ALTER TABLE _ddl_probe DROP COLUMN doomed` to *test* whether the feature
+            # exists before falling back to recreation; that is not a recommendation to drop
+            # `orders.legacy_promo_code`, so it must not satisfy this assertion.
+            stmt = re.compile(
+                r'alter\s+table\s+(?:if\s+exists\s+)?(?P<table>["\w][\w".]*)\s+'
+                r'drop\s+column\b(?P<tail>[^\n;]{0,200})'
+            )
+            # And reject the residual case where a named statement IS quoted, but only to say it
+            # is impossible ("you cannot run ALTER TABLE orders DROP COLUMN ... in DSQL").
+            negation = re.compile(r"(not support|unsupported|n't support|cannot|can't|isn't allowed|not allowed|not available|no support)")
+            if not text.strip():
+                evidence = "Agent produced no final answer text (timeout or error) — cannot pass"
+            else:
+                matches = list(stmt.finditer(text))
+                on_target = [
+                    m for m in matches
+                    if "orders" in m.group("table") and "legacy_promo_code" in m.group("tail")
+                ]
+                unnegated = [m for m in on_target if not negation.search(text[max(0, m.start() - 80):m.start()])]
+                if unnegated:
+                    passed = True
+                    evidence = f"Found native DROP COLUMN statement: {unnegated[0].group(0).strip()[:100]!r}"
+                elif on_target:
+                    evidence = f"'{on_target[0].group(0).strip()[:70]}' appears only inside a negation (claims it is unsupported)"
+                elif matches:
+                    evidence = (
+                        "DROP COLUMN appears, but not as a statement against orders.legacy_promo_code "
+                        f"(closest: {matches[0].group(0).strip()[:70]!r})"
+                    )
+                else:
+                    evidence = "No 'ALTER TABLE <table> DROP COLUMN' statement in the agent's answer"
+
+        # --- Assertion: does NOT fall back to the table-recreation sequence (eval 17) ---
+        # MUST stay above the "table recreation pattern" branch below. That branch (eval 5) PASSES
+        # when a recreation IS described; this assertion is its inverse, so if it fell through to
+        # that branch it would be graded exactly backwards — a recreation answer would score PASS.
+        elif "table-recreation sequence" in exp_lower or "table recreation sequence" in exp_lower:
+            recreation_markers = [
+                (r"insert\s+into[\s\S]{0,200}?\bselect\b", "INSERT ... SELECT data copy"),
+                (r"\b\w+_new\b", "_new staging table"),
+                (r"\bdrop\s+table\b", "DROP TABLE"),
+                (r"\brename\s+to\b", "RENAME TO"),
+            ]
+            found = [label for pat, label in recreation_markers if re.search(pat, text)]
+            if not text.strip():
+                evidence = "Agent produced no final answer text (timeout or error) — cannot pass"
+            elif found:
+                evidence = "Answer uses table-recreation steps, which DROP COLUMN must not require: " + ", ".join(found)
+            else:
+                passed = True
+                evidence = "No table-recreation steps (no INSERT ... SELECT, _new table, DROP TABLE, or RENAME TO)"
+
         # --- Assertion: Table Recreation Pattern ---
         elif "table recreation pattern" in exp_lower:
             if re.search(r"(table recreation|recreat|create.{0,40}new.{0,40}table.{0,40}(copy|migrat|move)|new table.{0,40}copy)", full_text):
@@ -453,8 +523,8 @@ def grade_eval(eval_item: dict, run_result: dict, judge_model: str | None = None
         # --- Fallback: keyword search ---
         # Note: evals 6-9 assertions (JSONB column type, TEXT[], INACTIVE/backup lifecycle)
         # are semantic — graded via `_llm_judge` when the eval sets `"llm_judge": true`.
-        # Regex branches below cover only evals 1-5 where verbatim tokens / tool-call topic
-        # matches are the right signal. See `_llm_judge` doc comment for rationale.
+        # Regex branches above cover only evals 1-5 and 17, where verbatim tokens / tool-call
+        # topic matches are the right signal. See `_llm_judge` doc comment for rationale.
         else:
             keywords = re.findall(r'\b[a-z_]{3,}\b', exp_lower)
             significant = [k for k in keywords if k not in (


### PR DESCRIPTION
Aurora DSQL shipped `ALTER TABLE ... DROP COLUMN` on 2026-08-03. The DSQL skill still routed a column drop through the Table Recreation Pattern, so agents generated a `CREATE new` / `INSERT ... SELECT` / `DROP TABLE` / `RENAME` sequence for what is now a one-line metadata change.

#### Related

- Aurora DSQL [release notes, 2026-08-03](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/release-notes.html) and [ALTER TABLE syntax support](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/alter-table-syntax-support.html)
- Mirror PR in `awslabs/mcp`: https://github.com/awslabs/mcp/pull/4556
- Adapter follow-up in `awslabs/aurora-dsql-orms`: https://github.com/awslabs/aurora-dsql-orms/pull/600

#### Changes

`DROP COLUMN` is synchronous and metadata-only. Unlike `VALIDATE CONSTRAINT` it has **no** `ALTER TABLE ASYNC` form and returns no `job_id` — worth stating explicitly, since steering written for the VALIDATE CONSTRAINT launch invites that generalization.

- **`references/development-guide.md`** — adds the rule to the file that is always loaded before schema changes. This is the highest-leverage edit: the routing table alone did not guarantee an agent reached the detailed rules.
- **`references/ddl-migrations/column-operations.md`** — replaces the recreation procedure with the native statement plus the rules that actually bite:
  - Primary key *key* columns are rejected with `0A000`; that case still needs table recreation.
  - `CASCADE` is required only for dependents **outside** the table (a view, an inbound foreign key) or a same-table `GENERATED ... STORED` column. A bare drop already sweeps the column's indexes and its same-table `CHECK`/`DEFAULT`/`UNIQUE`/outbound-FK constraints, so `CASCADE` there only widens the blast radius.
  - `CASCADE` itself fails `0A000` when the dependency chain reaches a PK key column (e.g. a PK column `GENERATED ALWAYS AS (dropped_col) STORED`) — no form of `DROP COLUMN` succeeds, so recreation is the fallback.
  - `IF EXISTS`, gradual storage reclamation, and the 255-active / 1,600-lifetime column budget.
- **`references/ddl-migrations/overview.md`** — moves `DROP COLUMN` out of the recreation table into the directly-supported list.
- **`references/mysql-migrations/{ddl-column-changes,type-mapping}.md`** — maps MySQL `DROP COLUMN` 1:1 and relocates the >3,000-row batching note to the type-change section, which is the path that actually copies rows.
- **`SKILL.md`** — Workflow 7 leads with the native path and is retitled, since it no longer covers only table recreation.
- Version bump `1.7.1` → `1.8.0` across `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, and `marketplace.json`.

Table recreation is unchanged for `ALTER COLUMN TYPE`, `SET NOT NULL`, `DROP CONSTRAINT`, and `MODIFY PRIMARY KEY`.

#### Testing

Adds **eval 17** as the regression net, with measured before/after:

| Skill content | Result |
|---|---|
| Pre-change | **0/2** — the agent recommends table recreation verbatim, citing the old guidance |
| This PR | **2/2** |

Two grader details worth review attention:

- It matches the agent's **final answer**, not the full transcript. `column-operations.md` documents both approaches, so grading against tool results would let a mere file read satisfy the assertion.
- Its branches sit **above** the existing `"table recreation pattern"` branch. That branch passes when recreation *is* present, so a negative assertion falling into it would be graded backwards and a regression would score PASS. Eval 5 and its branch are unchanged, and the verification suite re-grades eval 5 to prove it.

#### Known-stale neighbours, deliberately out of scope

`DROP CONSTRAINT`, `SET/DROP DEFAULT`, `DROP NOT NULL`, `DROP EXPRESSION`, and `ADD GENERATED AS IDENTITY` all shipped 2026-07-06 and are still documented here as requiring table recreation — including on lines this PR touches. Kept separate to hold this PR to one logical change; each needs its own verification. Note `DROP CONSTRAINT` is supported for CHECK/UNIQUE/FOREIGN KEY but **not** PRIMARY KEY, so that fix is a carve-out rather than a blanket removal.

#### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/agent-plugins/blob/main/LICENSE).
